### PR TITLE
Add Chimera 0.40-202 settings to Quality Presets

### DIFF
--- a/src/Configuration.Chimera.cs
+++ b/src/Configuration.Chimera.cs
@@ -29,7 +29,7 @@ namespace SPV3
   public class ConfigurationChimera : INotifyPropertyChanged
   {
     private bool _anisotropicFiltering = true;
-    private bool _blockLOD             = true;
+    private bool _blockLOD             = false;
     private int  _interpolation        = 8;
     private bool _uncapCinematic       = true;
 

--- a/src/Configuration.UserControl.xaml.cs
+++ b/src/Configuration.UserControl.xaml.cs
@@ -91,6 +91,8 @@ namespace SPV3
       _configuration.Shaders.DOF                = 0;
       _configuration.Shaders.MXAO               = 0;
       _configuration.Shaders.SSR                = false;
+      _configuration.Chimera.Interpolation      = 8;
+      _configuration.Chimera.BlockLOD           = false;
     }
 
     private void PresetLow(object sender, RoutedEventArgs e)
@@ -104,6 +106,8 @@ namespace SPV3
       _configuration.Shaders.DOF                = 0;
       _configuration.Shaders.MXAO               = 0;
       _configuration.Shaders.SSR                = false;
+      _configuration.Chimera.Interpolation      = 8;
+      _configuration.Chimera.BlockLOD           = false;
     }
 
     private void PresetMedium(object sender, RoutedEventArgs e)
@@ -117,6 +121,8 @@ namespace SPV3
       _configuration.Shaders.DOF                = 1;
       _configuration.Shaders.MXAO               = 0;
       _configuration.Shaders.SSR                = false;
+      _configuration.Chimera.Interpolation      = 8;
+      _configuration.Chimera.BlockLOD           = false;
     }
 
     private void PresetHigh(object sender, RoutedEventArgs e)
@@ -130,6 +136,8 @@ namespace SPV3
       _configuration.Shaders.DOF                = 1;
       _configuration.Shaders.MXAO               = 1;
       _configuration.Shaders.SSR                = false;
+      _configuration.Chimera.Interpolation      = 8;
+      _configuration.Chimera.BlockLOD           = false;
     }
 
     private void PresetVeryHigh(object sender, RoutedEventArgs e)
@@ -143,6 +151,8 @@ namespace SPV3
       _configuration.Shaders.DOF                = 2;
       _configuration.Shaders.MXAO               = 2;
       _configuration.Shaders.SSR                = false;
+      _configuration.Chimera.Interpolation      = 8;
+      _configuration.Chimera.BlockLOD           = false;
     }
 
     private void PresetUltra(object sender, RoutedEventArgs e)
@@ -156,6 +166,8 @@ namespace SPV3
       _configuration.Shaders.DOF                = 2;
       _configuration.Shaders.MXAO               = 2;
       _configuration.Shaders.SSR                = true;
+      _configuration.Chimera.Interpolation      = 8;
+      _configuration.Chimera.BlockLOD           = true;
     }
   }
 }

--- a/src/Configuration.UserControl.xaml.cs
+++ b/src/Configuration.UserControl.xaml.cs
@@ -167,7 +167,7 @@ namespace SPV3
       _configuration.Shaders.MXAO               = 2;
       _configuration.Shaders.SSR                = true;
       _configuration.Chimera.Interpolation      = 8;
-      _configuration.Chimera.BlockLOD           = true;
+      _configuration.Chimera.BlockLOD           = false;
     }
   }
 }


### PR DESCRIPTION
Set all Quality Presets to use Interpolation tier 8
Block LOD is now disabled by default.
Block LOD is disabled in all Quality Presets except Ultra