### PR TITLE
Decrease Default Settings

### DIFF
--- a/src/Configuration.Chimera.cs
+++ b/src/Configuration.Chimera.cs
@@ -28,7 +28,7 @@ namespace SPV3
 {
   public class ConfigurationChimera : INotifyPropertyChanged
   {
-    private bool _anisotropicFiltering = true;
+    private bool _anisotropicFiltering = false;
     private bool _blockLOD             = false;
     private int  _interpolation        = 8;
     private bool _uncapCinematic       = true;

--- a/src/Configuration.OpenSauce.cs
+++ b/src/Configuration.OpenSauce.cs
@@ -30,7 +30,7 @@ namespace SPV3
   {
     public class ConfigurationOpenSauce : INotifyPropertyChanged
     {
-      private bool   _bloom        = true;
+      private bool   _bloom        = false;
       private bool   _detailedMaps = true;
       private double _fieldOfView;
       private bool   _gBuffer          = true;

--- a/src/Configuration.Shaders.cs
+++ b/src/Configuration.Shaders.cs
@@ -42,6 +42,14 @@ namespace SPV3
       private bool _volumetricLighting = true;
       private bool _ssr                = true;
 
+      public bool DebandAvailable
+      {
+        get => _configuration.Mode.Equals(HXE.Kernel.Configuration.ConfigurationMode.SPV33);
+      }
+      public bool DynamicFlaresAvailable
+      {
+        get => !_configuration.Mode.Equals(HXE.Kernel.Configuration.ConfigurationMode.SPV33);
+      }
       public bool DynamicLensFlares
       {
         get => _dynamicLensFlares;

--- a/src/Configuration.Shaders.cs
+++ b/src/Configuration.Shaders.cs
@@ -41,21 +41,37 @@ namespace SPV3
       private int  _mxao               = 2;
       private bool _volumetricLighting = true;
       private bool _ssr                = true;
+      private bool _deband             = true;
+
+      public bool ModeIsSPV33()
+      {
+        if (System.IO.File.Exists(HXE.Paths.Version))
+        {
+          _configuration.Mode = Kernel.Configuration.ConfigurationMode.SPV33;
+          return true;
+        }
+        else
+          return false;
+      }
+
+      public bool DynamicFlaresAvailable
+      {
+        get => !ModeIsSPV33();
+      }
 
       public bool DebandAvailable
       {
-        get => _configuration.Mode.Equals(HXE.Kernel.Configuration.ConfigurationMode.SPV33);
+        get => ModeIsSPV33();
       }
-      public bool DynamicFlaresAvailable
-      {
-        get => !_configuration.Mode.Equals(HXE.Kernel.Configuration.ConfigurationMode.SPV33);
-      }
+
       public bool DynamicLensFlares
       {
         get => _dynamicLensFlares;
         set
         {
           if (value == _dynamicLensFlares) return;
+          if (value == true && _configuration.Mode != Kernel.Configuration.ConfigurationMode.SPV33)
+            _deband = false;
           _dynamicLensFlares = value;
           OnPropertyChanged();
         }
@@ -149,6 +165,19 @@ namespace SPV3
         }
       }
 
+      public bool Deband
+      {
+        get => _deband;
+        set
+        {
+          if (value == _deband) return;
+          if (value == true && _configuration.Mode == Kernel.Configuration.ConfigurationMode.SPV33)
+            _dynamicLensFlares = false;
+          _deband = value;
+          OnPropertyChanged();
+        }
+      }
+
       public event PropertyChangedEventHandler PropertyChanged;
 
       public void Save()
@@ -162,6 +191,7 @@ namespace SPV3
         _configuration.Shaders.MotionBlur         = (PostProcessing.MotionBlurOptions) MotionBlur;
         _configuration.Shaders.MXAO               = (PostProcessing.MxaoOptions) MXAO;
         _configuration.Shaders.SSR                = SSR;
+        _configuration.Shaders.Deband             = Deband;
 
         _configuration.Save();
       }
@@ -179,6 +209,7 @@ namespace SPV3
         MotionBlur         = (byte) _configuration.Shaders.MotionBlur;
         MXAO               = (byte) _configuration.Shaders.MXAO;
         SSR                = _configuration.Shaders.SSR;
+        Deband             = _configuration.Shaders.Deband;
       }
 
       [NotifyPropertyChangedInvocator]

--- a/src/Configuration.Shaders.cs
+++ b/src/Configuration.Shaders.cs
@@ -32,16 +32,16 @@ namespace SPV3
     {
       private readonly Kernel.Configuration _configuration = new Kernel.Configuration(Paths.Kernel);
 
-      private int  _dof                = 2;
-      private bool _dynamicLensFlares  = true;
-      private bool _filmGrain          = true;
+      private int  _dof                = 0;
+      private bool _dynamicLensFlares  = false;
+      private bool _filmGrain          = false;
       private bool _hudVisor           = true;
-      private bool _lensDirt           = true;
-      private int  _motionBlur         = 3;
-      private int  _mxao               = 2;
-      private bool _volumetricLighting = true;
-      private bool _ssr                = true;
-      private bool _deband             = true;
+      private bool _lensDirt           = false;
+      private int  _motionBlur         = 0;
+      private int  _mxao               = 0;
+      private bool _volumetricLighting = false;
+      private bool _ssr                = false;
+      private bool _deband             = false;
 
       public bool ModeIsSPV33()
       {

--- a/src/Configuration.UserControl.xaml
+++ b/src/Configuration.UserControl.xaml
@@ -289,13 +289,6 @@
                               IsEnabled="{Binding Loader.Shaders}"
                               ToolTip="Enables Dynamic Lens Flares effects." />
                 </DockPanel>
-                <DockPanel Visibility="{Binding Shaders.DebandAvailable, Converter={StaticResource BooleanToVisibilityConverter}}">
-                    <Label Content="Debanding:"
-                           IsEnabled="{Binding Loader.Shaders}" />
-                    <CheckBox IsChecked="{Binding Shaders.DynamicLensFlares}"
-                              IsEnabled="{Binding Loader.Shaders}"
-                              ToolTip="Removes banding artifacts/anomalies" />
-                </DockPanel>
                 <DockPanel>
                     <Label Content="SSR:"
                            IsEnabled="{Binding Loader.Shaders}" />
@@ -303,8 +296,15 @@
                               IsEnabled="{Binding Loader.Shaders}"
                               ToolTip="Enables Screen Space Ray Traced Reflections" />
                 </DockPanel>
+                <DockPanel Visibility="{Binding Shaders.DebandAvailable, Converter={StaticResource BooleanToVisibilityConverter}}">
+                  <Label Content="Debanding:"
+                                   IsEnabled="{Binding Loader.Shaders}" />
+                  <CheckBox IsChecked="{Binding Shaders.DynamicLensFlares}"
+                                      IsEnabled="{Binding Loader.Shaders}"
+                                      ToolTip="Removes banding artifacts/anomalies" />
+                </DockPanel>
 
-                <Label Content="Quality Presets"
+        <Label Content="Quality Presets"
                        HorizontalAlignment="Center"
                        Width="Auto"
                        FontSize="16"

--- a/src/Configuration.UserControl.xaml
+++ b/src/Configuration.UserControl.xaml
@@ -218,13 +218,14 @@
                 <DockPanel>
                     <Label Content="Post-Processing:" />
                     <CheckBox IsChecked="{Binding Loader.Shaders}"
-                              ToolTip="Enables SPV3.2's post-processing system." />
+                              ToolTip="Enables SPV3.2's or SPV3.3's post-processing system." />
                 </DockPanel>
                 <DockPanel>
                     <Label Content="Visor Overlay:"
                            IsEnabled="{Binding Loader.Shaders}" />
                     <CheckBox IsChecked="{Binding Shaders.HudVisor}"
-                              IsEnabled="{Binding Loader.Shaders}" />
+                              IsEnabled="{Binding Loader.Shaders}"
+                              ToolTip="Enables HUD extras like visor holograms and helmet bits"/>
                 </DockPanel>
                 <DockPanel>
                     <Label Content="Film Grain:"
@@ -238,20 +239,21 @@
                            IsEnabled="{Binding Loader.Shaders}" />
                     <CheckBox IsChecked="{Binding Shaders.VolumetricLighting}"
                               IsEnabled="{Binding Loader.Shaders}"
-                              ToolTip="Enhances lighting and bright objects." />
+                              ToolTip="Enables simulation of light scattering through fog" />
                 </DockPanel>
                 <DockPanel>
                     <Label Content="Lens Dirt:"
                            IsEnabled="{Binding Loader.Shaders}" />
                     <CheckBox IsChecked="{Binding Shaders.LensDirt}"
-                              IsEnabled="{Binding Loader.Shaders}" />
+                              IsEnabled="{Binding Loader.Shaders}"
+                              ToolTip="Enables dirt and scratches on visor" />
                 </DockPanel>
                 <DockPanel>
                     <Label Content="Motion Blur:"
                            IsEnabled="{Binding Loader.Shaders}" />
                     <ComboBox SelectedIndex="{Binding Shaders.MotionBlur}"
                               IsEnabled="{Binding Loader.Shaders}"
-                              ToolTip="Sets the Motion Blur level.">
+                              ToolTip="Sets the Motion Blur level. POMB is high quality motion blur.&#x0a;Fall back to 'Built-in' when the game runs at sub 25 FPS">
                         <ComboBoxItem Content="Off" />
                         <ComboBoxItem Content="Built-in" />
                         <ComboBoxItem Content="POMB Low" />
@@ -280,18 +282,26 @@
                         <ComboBoxItem Content="High" />
                     </ComboBox>
                 </DockPanel>
-                <DockPanel>
+                <DockPanel Visibility="{Binding Shaders.DynamicFlaresAvailable, Converter={StaticResource BooleanToVisibilityConverter}}">
                     <Label Content="Dynamic Lens Flares:"
                            IsEnabled="{Binding Loader.Shaders}" />
                     <CheckBox IsChecked="{Binding Shaders.DynamicLensFlares}"
                               IsEnabled="{Binding Loader.Shaders}"
                               ToolTip="Enables Dynamic Lens Flares effects." />
                 </DockPanel>
+                <DockPanel Visibility="{Binding Shaders.DebandAvailable, Converter={StaticResource BooleanToVisibilityConverter}}">
+                    <Label Content="Debanding:"
+                           IsEnabled="{Binding Loader.Shaders}" />
+                    <CheckBox IsChecked="{Binding Shaders.DynamicLensFlares}"
+                              IsEnabled="{Binding Loader.Shaders}"
+                              ToolTip="Removes banding artifacts/anomalies" />
+                </DockPanel>
                 <DockPanel>
                     <Label Content="SSR:"
                            IsEnabled="{Binding Loader.Shaders}" />
                     <CheckBox IsChecked="{Binding Shaders.SSR}"
-                              IsEnabled="{Binding Loader.Shaders}" />
+                              IsEnabled="{Binding Loader.Shaders}"
+                              ToolTip="Enables Screen Space Ray Traced Reflections" />
                 </DockPanel>
 
                 <Label Content="Quality Presets"

--- a/src/Configuration.UserControl.xaml.cs
+++ b/src/Configuration.UserControl.xaml.cs
@@ -82,98 +82,110 @@ namespace SPV3
 
     private void PresetVeryLow(object sender, RoutedEventArgs e)
     {
-      _configuration.OpenSauce.GBuffer          = false;
-      _configuration.Shaders.FilmGrain          = false;
-      _configuration.Shaders.VolumetricLighting = false;
-      _configuration.Shaders.LensDirt           = false;
-      _configuration.Shaders.DynamicLensFlares  = false;
-      _configuration.Shaders.MotionBlur         = 0;
-      _configuration.Shaders.DOF                = 0;
-      _configuration.Shaders.MXAO               = 0;
-      _configuration.Shaders.SSR                = false;
-      _configuration.Shaders.Deband             = false;
-      _configuration.Chimera.Interpolation      = 8;
-      _configuration.Chimera.BlockLOD           = false;
+      _configuration.OpenSauce.GBuffer            = false;
+      _configuration.Shaders.FilmGrain            = false;
+      _configuration.Shaders.VolumetricLighting   = false;
+      _configuration.Shaders.LensDirt             = false;
+      _configuration.Shaders.DynamicLensFlares    = false;
+      _configuration.Shaders.MotionBlur           = 0;
+      _configuration.Shaders.DOF                  = 0;
+      _configuration.Shaders.MXAO                 = 0;
+      _configuration.Shaders.SSR                  = false;
+      _configuration.Shaders.Deband               = false;
+      _configuration.OpenSauce.Bloom              = false;
+      _configuration.Chimera.Interpolation        = 0;
+      _configuration.Chimera.AnisotropicFiltering = false;
+      _configuration.Chimera.BlockLOD             = false;
     }
 
     private void PresetLow(object sender, RoutedEventArgs e)
     {
-      _configuration.OpenSauce.GBuffer          = true;
-      _configuration.Shaders.FilmGrain          = false;
-      _configuration.Shaders.VolumetricLighting = true;
-      _configuration.Shaders.LensDirt           = true;
-      _configuration.Shaders.DynamicLensFlares  = false;
-      _configuration.Shaders.MotionBlur         = 0;
-      _configuration.Shaders.DOF                = 0;
-      _configuration.Shaders.MXAO               = 0;
-      _configuration.Shaders.SSR                = false;
-      _configuration.Shaders.Deband             = false;
-      _configuration.Chimera.Interpolation      = 8;
-      _configuration.Chimera.BlockLOD           = false;
+      _configuration.OpenSauce.GBuffer            = true;
+      _configuration.Shaders.FilmGrain            = false;
+      _configuration.Shaders.VolumetricLighting   = true;
+      _configuration.Shaders.LensDirt             = true;
+      _configuration.Shaders.DynamicLensFlares    = false;
+      _configuration.Shaders.MotionBlur           = 0;
+      _configuration.Shaders.DOF                  = 0;
+      _configuration.Shaders.MXAO                 = 0;
+      _configuration.Shaders.SSR                  = false;
+      _configuration.Shaders.Deband               = false;
+      _configuration.OpenSauce.Bloom              = false;
+      _configuration.Chimera.Interpolation        = 8;
+      _configuration.Chimera.AnisotropicFiltering = false;
+      _configuration.Chimera.BlockLOD             = false;
     }
 
     private void PresetMedium(object sender, RoutedEventArgs e)
     {
-      _configuration.OpenSauce.GBuffer          = true;
-      _configuration.Shaders.FilmGrain          = false;
-      _configuration.Shaders.VolumetricLighting = true;
-      _configuration.Shaders.LensDirt           = true;
-      _configuration.Shaders.DynamicLensFlares  = false;
-      _configuration.Shaders.MotionBlur         = 1;
-      _configuration.Shaders.DOF                = 1;
-      _configuration.Shaders.MXAO               = 0;
-      _configuration.Shaders.SSR                = false;
-      _configuration.Shaders.Deband             = true;
-      _configuration.Chimera.Interpolation      = 8;
-      _configuration.Chimera.BlockLOD           = false;
+      _configuration.OpenSauce.GBuffer            = true;
+      _configuration.Shaders.FilmGrain            = false;
+      _configuration.Shaders.VolumetricLighting   = true;
+      _configuration.Shaders.LensDirt             = true;
+      _configuration.Shaders.DynamicLensFlares    = false;
+      _configuration.Shaders.MotionBlur           = 1;
+      _configuration.Shaders.DOF                  = 1;
+      _configuration.Shaders.MXAO                 = 0;
+      _configuration.Shaders.SSR                  = false;
+      _configuration.Shaders.Deband               = true;
+      _configuration.OpenSauce.Bloom              = true;
+      _configuration.Chimera.Interpolation        = 8;
+      _configuration.Chimera.AnisotropicFiltering = true;
+      _configuration.Chimera.BlockLOD             = false;
     }
 
     private void PresetHigh(object sender, RoutedEventArgs e)
     {
-      _configuration.OpenSauce.GBuffer          = true;
-      _configuration.Shaders.FilmGrain          = true;
-      _configuration.Shaders.VolumetricLighting = true;
-      _configuration.Shaders.LensDirt           = true;
-      _configuration.Shaders.DynamicLensFlares  = false;
-      _configuration.Shaders.MotionBlur         = 2;
-      _configuration.Shaders.DOF                = 1;
-      _configuration.Shaders.MXAO               = 1;
-      _configuration.Shaders.SSR                = false;
-      _configuration.Shaders.Deband             = true;
-      _configuration.Chimera.Interpolation      = 8;
-      _configuration.Chimera.BlockLOD           = false;
+      _configuration.OpenSauce.GBuffer            = true;
+      _configuration.Shaders.FilmGrain            = true;
+      _configuration.Shaders.VolumetricLighting   = true;
+      _configuration.Shaders.LensDirt             = true;
+      _configuration.Shaders.DynamicLensFlares    = false;
+      _configuration.Shaders.MotionBlur           = 2;
+      _configuration.Shaders.DOF                  = 1;
+      _configuration.Shaders.MXAO                 = 1;
+      _configuration.Shaders.SSR                  = false;
+      _configuration.Shaders.Deband               = true;
+      _configuration.OpenSauce.Bloom              = true;
+      _configuration.Chimera.Interpolation        = 8;
+      _configuration.Chimera.AnisotropicFiltering = true;
+      _configuration.Chimera.BlockLOD             = false;
     }
 
     private void PresetVeryHigh(object sender, RoutedEventArgs e)
     {
-      _configuration.OpenSauce.GBuffer          = true;
-      _configuration.Shaders.FilmGrain          = true;
-      _configuration.Shaders.VolumetricLighting = true;
-      _configuration.Shaders.LensDirt           = true;
-      _configuration.Shaders.DynamicLensFlares  = false;
-      _configuration.Shaders.MotionBlur         = 3;
-      _configuration.Shaders.DOF                = 2;
-      _configuration.Shaders.MXAO               = 2;
-      _configuration.Shaders.Deband             = true;
-      _configuration.Shaders.SSR                = false;
-      _configuration.Chimera.Interpolation      = 8;
-      _configuration.Chimera.BlockLOD           = false;
+      _configuration.OpenSauce.GBuffer            = true;
+      _configuration.Shaders.FilmGrain            = true;
+      _configuration.Shaders.VolumetricLighting   = true;
+      _configuration.Shaders.LensDirt             = true;
+      _configuration.Shaders.DynamicLensFlares    = false;
+      _configuration.Shaders.MotionBlur           = 3;
+      _configuration.Shaders.DOF                  = 2;
+      _configuration.Shaders.MXAO                 = 2;
+      _configuration.Shaders.Deband               = true;
+      _configuration.Shaders.SSR                  = false;
+      _configuration.OpenSauce.Bloom              = true;
+      _configuration.Chimera.Interpolation        = 8;
+      _configuration.Chimera.AnisotropicFiltering = true;
+      _configuration.Chimera.BlockLOD             = false;
     }
 
     private void PresetUltra(object sender, RoutedEventArgs e)
     {
-      _configuration.OpenSauce.GBuffer          = true;
-      _configuration.Shaders.FilmGrain          = true;
-      _configuration.Shaders.VolumetricLighting = true;
-      _configuration.Shaders.LensDirt           = true;
-      _configuration.Shaders.DynamicLensFlares  = true;
-      _configuration.Shaders.MotionBlur         = 3;
-      _configuration.Shaders.DOF                = 2;
-      _configuration.Shaders.MXAO               = 2;
-      _configuration.Shaders.SSR                = true;
-      _configuration.Shaders.Deband             = true;
-      _configuration.Chimera.Interpolation      = 8;
-      _configuration.Chimera.BlockLOD           = false;
+      _configuration.OpenSauce.GBuffer            = true;
+      _configuration.Shaders.FilmGrain            = true;
+      _configuration.Shaders.VolumetricLighting   = true;
+      _configuration.Shaders.LensDirt             = true;
+      _configuration.Shaders.DynamicLensFlares    = true;
+      _configuration.Shaders.MotionBlur           = 3;
+      _configuration.Shaders.DOF                  = 2;
+      _configuration.Shaders.MXAO                 = 2;
+      _configuration.Shaders.SSR                  = true;
+      _configuration.Shaders.Deband               = true;
+      _configuration.OpenSauce.Bloom              = true;
+      _configuration.Chimera.Interpolation        = 8;
+      _configuration.Chimera.AnisotropicFiltering = true;
+      _configuration.Chimera.BlockLOD             = false;
     }
   }
 }

--- a/src/Configuration.UserControl.xaml.cs
+++ b/src/Configuration.UserControl.xaml.cs
@@ -91,6 +91,7 @@ namespace SPV3
       _configuration.Shaders.DOF                = 0;
       _configuration.Shaders.MXAO               = 0;
       _configuration.Shaders.SSR                = false;
+      _configuration.Shaders.Deband             = false;
       _configuration.Chimera.Interpolation      = 8;
       _configuration.Chimera.BlockLOD           = false;
     }
@@ -106,6 +107,7 @@ namespace SPV3
       _configuration.Shaders.DOF                = 0;
       _configuration.Shaders.MXAO               = 0;
       _configuration.Shaders.SSR                = false;
+      _configuration.Shaders.Deband             = false;
       _configuration.Chimera.Interpolation      = 8;
       _configuration.Chimera.BlockLOD           = false;
     }
@@ -121,6 +123,7 @@ namespace SPV3
       _configuration.Shaders.DOF                = 1;
       _configuration.Shaders.MXAO               = 0;
       _configuration.Shaders.SSR                = false;
+      _configuration.Shaders.Deband             = true;
       _configuration.Chimera.Interpolation      = 8;
       _configuration.Chimera.BlockLOD           = false;
     }
@@ -136,6 +139,7 @@ namespace SPV3
       _configuration.Shaders.DOF                = 1;
       _configuration.Shaders.MXAO               = 1;
       _configuration.Shaders.SSR                = false;
+      _configuration.Shaders.Deband             = true;
       _configuration.Chimera.Interpolation      = 8;
       _configuration.Chimera.BlockLOD           = false;
     }
@@ -150,6 +154,7 @@ namespace SPV3
       _configuration.Shaders.MotionBlur         = 3;
       _configuration.Shaders.DOF                = 2;
       _configuration.Shaders.MXAO               = 2;
+      _configuration.Shaders.Deband             = true;
       _configuration.Shaders.SSR                = false;
       _configuration.Chimera.Interpolation      = 8;
       _configuration.Chimera.BlockLOD           = false;
@@ -166,6 +171,7 @@ namespace SPV3
       _configuration.Shaders.DOF                = 2;
       _configuration.Shaders.MXAO               = 2;
       _configuration.Shaders.SSR                = true;
+      _configuration.Shaders.Deband             = true;
       _configuration.Chimera.Interpolation      = 8;
       _configuration.Chimera.BlockLOD           = false;
     }

--- a/src/Main.Load.cs
+++ b/src/Main.Load.cs
@@ -68,7 +68,7 @@ namespace SPV3
         }
 
         hxe.Load();
-        hxe.Mode               = Kernel.Configuration.ConfigurationMode.SPV32;
+        hxe.Mode               = Kernel.Configuration.ConfigurationMode.SPV33;
         hxe.Tweaks.Sensor      = true;          /* forcefully enable motion sensor   */
         hxe.Main.Reset         = true;          /* improve loading stability         */
         hxe.Main.Patch         = true;          /* improve loading stability         */

--- a/src/Main.Load.cs
+++ b/src/Main.Load.cs
@@ -85,6 +85,10 @@ namespace SPV3
         hxe.Tweaks.Cinematic   = spv3.Cinematic;
         hxe.Tweaks.Unload      = !spv3.Shaders;
 
+        if (File.Exists(HXE.Paths.Version))
+        {
+          hxe.Mode = Kernel.Configuration.ConfigurationMode.SPV33;
+        }
         if (chimera.Exists())
         {
           chimera.Load();

--- a/src/Main.Load.cs
+++ b/src/Main.Load.cs
@@ -96,7 +96,7 @@ namespace SPV3
         else
         {
           chimera.Interpolation        = 8;
-          chimera.AnisotropicFiltering = true;
+          chimera.AnisotropicFiltering = false;
           chimera.UncapCinematic       = true;
           chimera.BlockLOD             = false;
         }


### PR DESCRIPTION
-- SPV3 POST-PROCESSING --
The following were changed to OFF by default:
^ Bloom
^ Lens Dirt
^ Dynamic Lens Flares (exclusive to SPV3.2)
^ Volumetric Lighting
^ FXAA (anti-aliasing)
^ Film Grain
^ Motion Blur
^ MXAO (MartMcFly's Ambient Obscurance)
^ DOF (Depth of Field)
^ SSR (Screen-Space Reflections)
^ Debanding

-- CHIMERA 2017 --
* Interpolation decremented from 9 to 8. I thought I changed that already...
* Anisotropic Filtering initialized to false. Technically, this is Halo's built-in setting, but Chimera can enforce it whereas Halo matches the setting to capable GPUs listed in its config.txt file...and doesn't auto-enable it when it can.
* BlockLOD bool initialized to false. Enabled == very expensive performance hit with small benefit to model quality at distances. I thought I fixed this already.