### PR TITLE
Is this Bandaid big enough?

### DIFF
--- a/hxe/kernel/src/HCE/Executable.cs
+++ b/hxe/kernel/src/HCE/Executable.cs
@@ -55,9 +55,28 @@ namespace HXE.HCE
     public static Executable Detect()
     {
       var hce = Detection.Infer();
+      string fullName = "";
 
-      if (System.IO.File.Exists(hce.FullName))
-        return (Executable) hce.FullName;
+      try
+      {
+        fullName = hce.FullName;
+      }
+      catch(System.Exception e)
+      {
+        using (System.Windows.Forms.OpenFileDialog ofd = new System.Windows.Forms.OpenFileDialog())
+        {
+          ofd.InitialDirectory = GetFolderPath(SpecialFolder.Desktop);
+          ofd.Filter = "Halo Custom Edition (haloce.exe)|haloce.exe|Halo Retail/Trial (halo.exe)|halo.exe";
+          ofd.FilterIndex = 1;
+          ofd.RestoreDirectory = true;
+
+          if (ofd.ShowDialog() == System.Windows.Forms.DialogResult.OK)
+            fullName = GetFullPath(ofd.FileName);
+        }
+      }
+
+        if (System.IO.File.Exists(fullName))
+          return (Executable)fullName;
 
       throw new FileNotFoundException("Could not detect executable on the filesystem.");
     }
@@ -104,7 +123,7 @@ namespace HXE.HCE
         if (Video.NoGamma)
           ApplyArgument(args, "-nogamma ");
 
-        if (Video.Mode)
+        if (Video.DisplayMode)
         {
           if (Video.Width > 0 && Video.Height > 0 && Video.Refresh > 0) /* optional refresh rate */
             ApplyArgument(args, $"-vidmode {Video.Width},{Video.Height},{Video.Refresh} ");
@@ -194,13 +213,13 @@ namespace HXE.HCE
 
     public class VideoOptions
     {
-      public bool   Mode    { get; set; }
-      public bool   Window  { get; set; }
-      public ushort Width   { get; set; }
-      public ushort Height  { get; set; }
-      public ushort Refresh { get; set; }
-      public byte   Adapter { get; set; }
-      public bool   NoGamma { get; set; }
+      public bool   DisplayMode { get; set; }
+      public bool   Window      { get; set; }
+      public ushort Width       { get; set; }
+      public ushort Height      { get; set; }
+      public ushort Refresh     { get; set; }
+      public byte   Adapter     { get; set; }
+      public bool   NoGamma     { get; set; }
     }
 
     public class ProfileOptions

--- a/hxe/kernel/src/Program.cs
+++ b/hxe/kernel/src/Program.cs
@@ -197,7 +197,7 @@ namespace HXE
 
         if (a.Length < 2) return;
 
-        hce.Video.Mode   = true;
+        hce.Video.DisplayMode = true;
         hce.Video.Width  = ushort.Parse(a[0]);
         hce.Video.Height = ushort.Parse(a[1]);
 

--- a/hxe/kernel/src/SPV3/PostProcessing.cs
+++ b/hxe/kernel/src/SPV3/PostProcessing.cs
@@ -74,6 +74,7 @@ namespace HXE.SPV3
     public ExperimentalPostProcessing Experimental       { get; set; } = new ExperimentalPostProcessing();
     public bool                       SSR                { get; set; } = false;
     public bool                       Deband             { get; set; } = false;
+    public bool                       AdaptiveHDR        { get; set; } = false;
 
     /// <summary>
     ///   Experimental overrides for HCE.

--- a/hxe/kernel/src/Settings.xaml.cs
+++ b/hxe/kernel/src/Settings.xaml.cs
@@ -27,7 +27,7 @@ namespace HXE
   /// <summary>
   ///   Interaction logic for Settings.xaml
   /// </summary>
-  public partial class Settings
+  public partial class Settings : Window
   {
     private          Kernel.Configuration       _configuration = new Kernel.Configuration(Paths.Configuration);
     private readonly System.Diagnostics.Process _process       = System.Diagnostics.Process.GetCurrentProcess();
@@ -162,7 +162,11 @@ namespace HXE
 
       if (_process.ProcessName == "hxe")
         Exit.WithCode(Exit.Code.Success);
-      else Hide();
+      else
+      {
+        DialogResult = true;
+        Close();
+      }
     }
 
     private void PrintConfiguration()

--- a/spv3/loader/src/Configuration.Shaders.cs
+++ b/spv3/loader/src/Configuration.Shaders.cs
@@ -21,7 +21,6 @@
 
 using System.ComponentModel;
 using System.Runtime.CompilerServices;
-using HXE;
 using HXE.SPV3;
 using SPV3.Annotations;
 
@@ -31,8 +30,9 @@ namespace SPV3
   {
     public class ConfigurationShaders : INotifyPropertyChanged
     {
-      private readonly HXE.Kernel.Configuration _configuration = new HXE.Kernel.Configuration(Paths.Kernel);
+      private readonly HXE.Kernel.Configuration _configuration = Kernel.hxe;
 
+      private bool _adaptiveHDR        = false;
       private int  _dof                = 0;
       private bool _dynamicLensFlares  = false;
       private bool _filmGrain          = false;
@@ -59,11 +59,24 @@ namespace SPV3
           return false;
       }
 
+      public bool AdaptiveHDR
+      {
+        get => _adaptiveHDR;
+        set
+        {
+          if (value == _adaptiveHDR) return;
+          _adaptiveHDR = value;
+          OnPropertyChanged();
+        }
+      }
+
+      // Remove when we have Halo global variables for both DLF and Deband. Still used by XML bindings.
       public bool DynamicFlaresAvailable
       {
         get => !ModeIsSPV33();
       }
 
+      // Remove when we have Halo global variables for both DLF and Deband. Still used by XML bindings.
       public bool DebandAvailable
       {
         get => ModeIsSPV33();
@@ -75,8 +88,6 @@ namespace SPV3
         set
         {
           if (value == _dynamicLensFlares) return;
-          if (value == true && _configuration.Mode != HXE.Kernel.Configuration.ConfigurationMode.SPV33)
-            _deband = false;
           _dynamicLensFlares = value;
           OnPropertyChanged();
         }
@@ -176,8 +187,6 @@ namespace SPV3
         set
         {
           if (value == _deband) return;
-          if (value == true && _configuration.Mode == HXE.Kernel.Configuration.ConfigurationMode.SPV33)
-            _dynamicLensFlares = false;
           _deband = value;
           OnPropertyChanged();
         }
@@ -187,6 +196,7 @@ namespace SPV3
 
       public void Save()
       {
+        _configuration.Shaders.AdaptiveHDR        = AdaptiveHDR;
         _configuration.Shaders.DynamicLensFlares  = DynamicLensFlares;
         _configuration.Shaders.FilmGrain          = FilmGrain;
         _configuration.Shaders.HudVisor           = HudVisor;
@@ -205,6 +215,7 @@ namespace SPV3
       {
         _configuration.Load();
 
+        AdaptiveHDR        = _configuration.Shaders.AdaptiveHDR;
         DynamicLensFlares  = _configuration.Shaders.DynamicLensFlares;
         FilmGrain          = _configuration.Shaders.FilmGrain;
         HudVisor           = _configuration.Shaders.HudVisor;

--- a/spv3/loader/src/Configuration.UserControl.xaml
+++ b/spv3/loader/src/Configuration.UserControl.xaml
@@ -122,7 +122,7 @@
         </DockPanel>
         <DockPanel Margin="0,5,0,0">
           <Label Content="Display Mode:" />
-          <ComboBox SelectedIndex="{Binding Loader.Mode}"
+          <ComboBox SelectedIndex="{Binding Loader.DisplayMode}"
                     Width="125"
                     HorizontalAlignment="Left">
             <ComboBoxItem Content="Fullscreen"
@@ -220,14 +220,23 @@
         <DockPanel>
           <Label Content="Post-Processing:" />
           <CheckBox IsChecked="{Binding Loader.Shaders}"
+                    Unchecked="Update_AdaptiveHDRIsReady"
                     ToolTip="Enables SPV3's post-processing system." />
+        </DockPanel>
+        <DockPanel>
+          <Label Content="Adaptive HDR:"
+                 IsEnabled="{Binding Loader.Shaders}"/>
+          <CheckBox IsChecked="{Binding Shaders.AdaptiveHDR}"
+                    IsEnabled="{Binding Loader.Shaders}"
+                    Unchecked="AdaptiveHDR_Unchecked"
+                    ToolTip="Enables High Dynamic Range. Adapts to the scene's light levels. Required for Bloom and Screen Space Reflections to render corectly." />
         </DockPanel>
         <DockPanel>
           <Label Content="Visor Overlay:"
                  IsEnabled="{Binding Loader.Shaders}" />
           <CheckBox IsChecked="{Binding Shaders.HudVisor}"
                     IsEnabled="{Binding Loader.Shaders}"
-                    ToolTip="Enables HUD extras like visor holograms and helmet bits"/>
+                    ToolTip="Enables HUD extras like visor holograms, helmet bits, and water droplets, and ice."/>
         </DockPanel>
         <DockPanel>
           <Label Content="Film Grain:"
@@ -292,20 +301,12 @@
                     ToolTip="Enables Dynamic Lens Flares effects." />
         </DockPanel>
         <DockPanel>
-          <Label Content="Adaptive HDR:"
-                 IsEnabled="{Binding Loader.Shaders}"/>
-          <CheckBox IsChecked="{Binding Loader.AHDR}"
-                    IsEnabled="{Binding Loader.Shaders}"
-                    Unchecked="AHDR_Unchecked"
-                    ToolTip="Enables High Dynamic Range. Adapts to the scene's light levels." />
-        </DockPanel>
-        <DockPanel>
           <Label Content="SSR:"
                  IsEnabled="{Binding Loader.Shaders}" />
           <CheckBox IsChecked="{Binding Shaders.SSR}"
-                    IsEnabled="{Binding Loader.AHDR}"
+                    IsEnabled="{Binding AdaptiveHDRIsReady}"
                     Checked="SSR_Or_ResolutionChanged"
-                    ToolTip="Enables Screen Space Ray Traced Reflections." />
+                    ToolTip="Requires Adaptive HDR. Enables Screen Space Ray Traced Reflections." />
         </DockPanel>
         <DockPanel Visibility="{Binding Shaders.DebandAvailable, Converter={StaticResource BooleanToVisibilityConverter}}">
           <Label Content="Debanding:"
@@ -424,6 +425,7 @@
         <DockPanel>
           <Label Content="Bloom:" />
           <CheckBox IsChecked="{Binding OpenSauce.Bloom}"
+                    IsEnabled="{Binding AdaptiveHDRIsReady}"
                     ToolTip="Requires Adaptive HDR. Adds glowy highlights to visual bright spots." />
         </DockPanel>
 

--- a/spv3/loader/src/Configuration.UserControl.xaml.cs
+++ b/spv3/loader/src/Configuration.UserControl.xaml.cs
@@ -81,15 +81,23 @@ namespace SPV3
                       "This should only be used on low-end computers as a last resort.");
     }
 
-    private void AHDR_Unchecked(object sender, RoutedEventArgs e)
+    private void AdaptiveHDR_Unchecked(object sender, RoutedEventArgs e)
     {
       _configuration.OpenSauce.Bloom = false;
       _configuration.Shaders.SSR = false;
+      MessageBox.Show("WARNING: Bloom and Screen Space Reflections require Adaptive HDR to render correctly");
+      Update_AdaptiveHDRIsReady(sender, e);
+    }
+
+    private void Update_AdaptiveHDRIsReady(object sender, RoutedEventArgs e)
+    {
+      _configuration.AdaptiveHDRIsReady = true ==_configuration.Loader.Shaders == _configuration.Shaders.AdaptiveHDR;
     }
 
     private void PresetVeryLow(object sender, RoutedEventArgs e)
     {
       _configuration.OpenSauce.GBuffer = false;
+      _configuration.Shaders.AdaptiveHDR = false;
       _configuration.Shaders.FilmGrain = false;
       _configuration.Shaders.VolumetricLighting = false;
       _configuration.Shaders.LensDirt = false;
@@ -108,6 +116,7 @@ namespace SPV3
     private void PresetLow(object sender, RoutedEventArgs e)
     {
       _configuration.OpenSauce.GBuffer = true;
+      _configuration.Shaders.AdaptiveHDR = false;
       _configuration.Shaders.FilmGrain = false;
       _configuration.Shaders.VolumetricLighting = true;
       _configuration.Shaders.LensDirt = true;
@@ -126,6 +135,7 @@ namespace SPV3
     private void PresetMedium(object sender, RoutedEventArgs e)
     {
       _configuration.OpenSauce.GBuffer = true;
+      _configuration.Shaders.AdaptiveHDR = true;
       _configuration.Shaders.FilmGrain = false;
       _configuration.Shaders.VolumetricLighting = true;
       _configuration.Shaders.LensDirt = true;
@@ -144,6 +154,7 @@ namespace SPV3
     private void PresetHigh(object sender, RoutedEventArgs e)
     {
       _configuration.OpenSauce.GBuffer = true;
+      _configuration.Shaders.AdaptiveHDR = true;
       _configuration.Shaders.FilmGrain = true;
       _configuration.Shaders.VolumetricLighting = true;
       _configuration.Shaders.LensDirt = true;
@@ -162,6 +173,7 @@ namespace SPV3
     private void PresetVeryHigh(object sender, RoutedEventArgs e)
     {
       _configuration.OpenSauce.GBuffer = true;
+      _configuration.Shaders.AdaptiveHDR = true;
       _configuration.Shaders.FilmGrain = true;
       _configuration.Shaders.VolumetricLighting = true;
       _configuration.Shaders.LensDirt = true;
@@ -180,6 +192,7 @@ namespace SPV3
     private void PresetUltra(object sender, RoutedEventArgs e)
     {
       _configuration.OpenSauce.GBuffer = true;
+      _configuration.Shaders.AdaptiveHDR = true;
       _configuration.Shaders.FilmGrain = true;
       _configuration.Shaders.VolumetricLighting = true;
       _configuration.Shaders.LensDirt = true;

--- a/spv3/loader/src/Configuration.cs
+++ b/spv3/loader/src/Configuration.cs
@@ -34,6 +34,8 @@ namespace SPV3
     public HXE.Settings           Settings  { get; set; } = new HXE.Settings(hxe);
     public HXE.Positions          Positions { get; set; } = new HXE.Positions();
 
+    public bool AdaptiveHDRIsReady = false; // see Configuration.UserControl.xaml.cs, Update_AdaptiveHDRIsReady().
+
     public void Load()
     {
       spv3 = Loader;
@@ -84,6 +86,7 @@ namespace SPV3
 
       Settings = new HXE.Settings(hxe);
       Settings.ShowDialog();
+      if (Settings.DialogResult == true)
       Kernel.Load();
     }
 

--- a/spv3/loader/src/Main.Load.cs
+++ b/spv3/loader/src/Main.Load.cs
@@ -131,7 +131,7 @@ namespace SPV3
           },
           Video = new Executable.VideoOptions
           {
-            Mode    = spv3.Vsync == false && spv3.Framerate > 0,
+            DisplayMode = spv3.Vsync == false && spv3.Framerate > 0,
             Width   = spv3.Native ? (ushort) 0 : spv3.Width,
             Height  = spv3.Native ? (ushort) 0 : spv3.Height,
             Refresh = spv3.Framerate,


### PR DESCRIPTION
ha ha
I'm going to the deepest layer of hell because of this, aren't I?

* Added more functionality for Adaptive HDR.
* Added Version byte to Loader/Kernel Configuration files, starting at int20.
* Rewrote GammaEnabled checkbox to set Gamma to 0.
* Renamed ambiguous "Mode" variable to "DisplayMode".
* Forgot things over time because I didn't split this into multiple commits.

HXE.HCE.Executable
* Handle hce.FullName exceptions by prompting the user with an OpenFileDialog.

SPV3.Configuration
* Moved AHDR variable from ConfigurationLoader to ConfigurationShaders. As it should have been from the beginning.
* Added AdaptiveHDRIsReady bool for determining when AdaptiveHDR and Post Processing are enabled.

SPV3.Configuration.Loader
* Rename Mode and _mode to DisplayMode and _displayMode, respectively.
* Removed UpdateNative() in favor of one-line `var = !value` for relevant variables.
* Removed redundant UpdateWindowBorderless() call from Load(); It's called when when setting some variables.
* Moved AHDR and _ahdr to Configuration.Shaders.AdaptiveHDR and _adaptiveHDR.

SPV3.Configuration.Shaders
* Removed unnecessary `using HXE` statement.
* Added AdaptiveHDR and _adaptiveHDR.
* Removed version-check from DynamicLensFlares and Deband. They can eventually be enabled together.
* Replaced `new Kernel Configuration` with the static SPV3.Kernel.hxe.

SPV3.Configuration.UserControl
* Added Warning message box for AdaptiveHDR_Unchecked().
* Added Adaptive HDR to quality presets.
* Added Update_AdaptiveHDRIsReady(). Used by unchecking Adaptive HDR or Post Processing.
* Fixed IsEnabled logic for Bloom and SSR.
* Added condensation to Visor Overlay tooltip.