### PR TITLE
Input revision, move MenuBack and MenuAccept to a new Dictionary

### DIFF
--- a/hxe/kernel/src/HCE/Profile.cs
+++ b/hxe/kernel/src/HCE/Profile.cs
@@ -151,7 +151,18 @@ namespace HXE.HCE
           var value  = (byte) mapping.Key;  /* action */
           var offset = (int) mapping.Value; /* button */
 
-          Debug("Assigning input to action - " + mapping.Key + " -> " + mapping.Value);
+          Debug("Assigning input to action - " + mapping.Key + " -> " + mapping.Value);          
+
+          ms.Position = offset;
+          bw.Write(value);
+        }
+
+        foreach (var bitbind in Input.BitBinding)
+        {
+          var value  = (byte) bitbind.Key;   /* button */
+          var offset = (int)  bitbind.Value; /* action */
+
+          Debug("Assigning input to action - " + bitbind.Key + " -> " + bitbind.Value);
 
           ms.Position = offset;
           bw.Write(value);
@@ -335,6 +346,19 @@ namespace HXE.HCE
 
           if (!Input.Mapping.ContainsKey(key))
             Input.Mapping.Add(key, value);
+        }
+
+        Input.BitBinding = new Dictionary<OddValues, OddOffsets>();
+
+        foreach (var offset in Enum.GetValues(typeof(OddOffsets)))
+        {
+          reader.BaseStream.Seek((int) offset, SeekOrigin.Begin);
+
+          var key   = (OddValues) reader.ReadByte();
+          var value = (OddOffsets) offset;
+
+          if (!Input.BitBinding.ContainsKey(key))
+            Input.BitBinding.Add(key, value);
         }
 
         if ((int) Details.Colour == 0xFF)
@@ -657,8 +681,6 @@ namespace HXE.HCE
         Flashlight      = 0x05, /* actions  */
         ScopeZoom       = 0x0B, /* actions  */
         Action          = 0x02, /* actions  */
-        MenuAccept      = 0xFF, /* misc.    */
-        MenuBack        = 0xFF, /* misc.    */
         Say             = 0x0F, /* misc.    */
         SayToTeam       = 0x10, /* misc.    */
         SayToVehicle    = 0x11, /* misc.    */
@@ -695,7 +717,30 @@ namespace HXE.HCE
         Back  = 0x236  /* home - back                     */
       }
 
+      public enum OddOffsets
+      {
+        MenuAccept = 0x32A, /* misc.           */
+        MenuBack   = 0x32C, /* misc.           */
+      }
+
+      public enum OddValues // bit mask?
+      {
+        Button1  = 0x0000, /* face - button a                */ //confirmed
+        Button2  = 0x0100, /* face - button b                */ //confirmed
+        Button3  = 0x0200, /* face - button x                */
+        Button4  = 0x0300, /* face - button y                */
+        Button5  = 0x0400, /* shoulder - L shoulder, white   */
+        Button6  = 0x0500, /* shoulder - R shoulder, black   */
+        Button7  = 0x0600, /* home - back                    */
+        Button8  = 0x0700, /* home - start                   */ //confirmed
+        Button9  = 0x0800, /* analogue - left  stick - click */
+        Button10 = 0x0900, /* analogue - right stick - click */
+        //todo: confirm the other values
+      }
+
       public Dictionary<Action, Button> Mapping = new Dictionary<Action, Button>();
+
+      public Dictionary<OddValues, OddOffsets> BitBinding = new Dictionary<OddValues, OddOffsets>();
     }
   }
 }

--- a/hxe/kernel/src/Kernel.cs
+++ b/hxe/kernel/src/Kernel.cs
@@ -315,7 +315,7 @@ namespace HXE
           }
           catch (Exception e)
           {
-            if (i == 0)
+            if (i == 0 && (uint)e.HResult == 0x80070002) // FileNotFoundException
             {
               var lastprof = (LastProfile)Custom.LastProfile(executable.Profile.Path);
               var scaffold = lastprof.Exists() && System.IO.File.Exists(Custom.Profile(executable.Profile.Path, lastprof.Profile));
@@ -487,9 +487,7 @@ namespace HXE
             {Profile.ProfileInput.Action.ThrowGrenade, Profile.ProfileInput.Button.LB},
             {Profile.ProfileInput.Action.Flashlight, Profile.ProfileInput.Button.LT},
             {Profile.ProfileInput.Action.MeleeAttack, Profile.ProfileInput.Button.RB},
-            {Profile.ProfileInput.Action.FireWeapon, Profile.ProfileInput.Button.RT},
-            {Profile.ProfileInput.Action.MenuBack, Profile.ProfileInput.Button.Back},
-            {Profile.ProfileInput.Action.MenuAccept, Profile.ProfileInput.Button.Start}
+            {Profile.ProfileInput.Action.FireWeapon, Profile.ProfileInput.Button.RT}
           };
 
           Core("BLAM.INPUT: Input overrides have been applied accordingly.");

--- a/hxe/kernel/src/Kernel.cs
+++ b/hxe/kernel/src/Kernel.cs
@@ -490,6 +490,12 @@ namespace HXE
             {Profile.ProfileInput.Action.FireWeapon, Profile.ProfileInput.Button.RT}
           };
 
+          blam.Input.BitBinding = new Dictionary<Profile.ProfileInput.OddValues, Profile.ProfileInput.OddOffsets>
+          {
+            {Profile.ProfileInput.OddValues.Button1, Profile.ProfileInput.OddOffsets.MenuAccept},
+            {Profile.ProfileInput.OddValues.Button2, Profile.ProfileInput.OddOffsets.MenuBack}
+          };
+
           Core("BLAM.INPUT: Input overrides have been applied accordingly.");
         }
       }

--- a/hxe/kernel/src/SPV3/Initiation.cs
+++ b/hxe/kernel/src/SPV3/Initiation.cs
@@ -59,16 +59,22 @@ namespace HXE.SPV3
 
       var output = new StringBuilder();
 
-      if (Resume.Initiation != null && Progress.Mission.Initiation != null)
+      if (Resume != null && Progress != null)
       {
-        output.AppendLine(";;;  Set Mission/Progress");
-        output.AppendLine($"set {Resume.Initiation} {Progress.Mission.Initiation}");
+        if (Resume.Initiation != null && Progress.Mission.Initiation != null)
+        {
+          output.AppendLine(";;;  Set Mission/Progress");
+          output.AppendLine($"set {Resume.Initiation} {Progress.Mission.Initiation}");
+        } 
       }
 
-      if (Progress.Difficulty.Initiation != null)
-      {
-        output.AppendLine(";;;  Set Difficulty");
-        output.AppendLine($"game_difficulty_set {Progress.Difficulty.Initiation}");
+      if (Progress != null) 
+      { 
+        if (Progress.Difficulty.Initiation != null)
+        {
+          output.AppendLine(";;;  Set Difficulty");
+          output.AppendLine($"game_difficulty_set {Progress.Difficulty.Initiation}");
+        }
       }
 
       output.AppendLine(";;;  Toggle cinematic black bars");


### PR DESCRIPTION
Unlike other Actions, those two are offsets with input bitmasks assigned as values.

I probably need to take another look at the memory pointer. Does it need to be reset to Position 0?