### PR TITLE
Fix Audio settings; Copy spv3 loader settings to the hxe kernel before invocation

### DIFF
--- a/hxe/kernel/src/Kernel.cs
+++ b/hxe/kernel/src/Kernel.cs
@@ -97,8 +97,7 @@ namespace HXE
     {
       /* Clear log file */
       {
-        FileInfo fileInfo = new FileInfo(Paths.Exception);
-        if (fileInfo.Length > 1048576) // If larger than 1 MiB, ...
+        if (new FileInfo(Paths.Exception).Length > 1048576) // If larger than 1 MiB, ...
           System.IO.File.WriteAllText(Paths.Exception, ""); // ...clear log.
       }
 

--- a/spv3/loader/src/Main.Load.cs
+++ b/spv3/loader/src/Main.Load.cs
@@ -114,6 +114,7 @@ namespace SPV3
         if (openSauce.Camera.FieldOfView < 40.00 || openSauce.Camera.FieldOfView > 180.00)
           openSauce.Camera.CalculateFOV();
 
+        Kernel.CopyLoaderToKernel();
 
         Kernel.spv3.Save(); /* saves to %APPDATA%\SPV3\loader-0x##.bin                */
         Kernel.hxe.Save();  /* saves to %APPDATA%\SPV3\kernel-0x##.bin                */
@@ -148,7 +149,7 @@ namespace SPV3
           {
             NoVideo = true
           }
-        }, Kernel.hxe);;
+        }, Kernel.hxe);
       }
 
       [NotifyPropertyChangedInvocator]


### PR DESCRIPTION
HXE.Kernel
* Part of a change to the HXE Kernel exception log file was reverted. We don't need to keep the FileInfo instance, so the variable declaration has been removed again.

SPV3.Main.Load
* To ensure settings aren't conflicting between the hxe kernel and spv3 loader instances, the loader settings are assigned to their HXE kernel equivalents before the HXE kernel is invoked. **This may have fixed the EAX toggle issue.**

