### PR TITLE
Tweak installer

### DIFF
--- a/hxe/kernel/src/Patcher.cs
+++ b/hxe/kernel/src/Patcher.cs
@@ -114,6 +114,8 @@ namespace HXE
     /// <param name="exePath">Path to Halo executable</param>
     public void Write(uint cfg, string exePath)
     {
+      var FilteredPatches    = new List<PatchGroup>();
+
       /** Configurable */
       bool DRM               = (cfg & EXEP.DISABLE_DRM_AND_KEY_CHECKS) != 0;
       bool NoGamma           = (cfg & EXEP.DISABLE_SYSTEM_GAMMA)       != 0;
@@ -121,7 +123,6 @@ namespace HXE
       bool NoMouseAccel      = (cfg & EXEP.DISABLE_MOUSE_ACCELERATION) != 0;
       bool BlockCamShake     = (cfg & EXEP.BLOCK_CAMERA_SHAKE)         != 0;
       bool BlockDescopeOnDMG = (cfg & EXEP.PREVENT_DESCOPING_ON_DMG)   != 0;
-      var FilteredPatches    = new List<PatchGroup>();
 
       /** Overrides */
       bool LAA            = true; // (cfg & EXEP.ENABLE_LARGE_ADDRESS_AWARE) != 0;
@@ -131,136 +132,136 @@ namespace HXE
       bool NoEULA         = true; // (cfg & EXEP.DISABLE_EULA)               != 0;
       bool NoRegistryExit = true; // (cfg & EXEP.DISABLE_REG_EXIT_STATE)     != 0;
       bool BlockUpdates   = true; // (cfg & EXEP.BLOCK_UPDATE_CHECKS)        != 0;
-      
-      
+
+
       /** Filter PatchGroups for those requested 
        * NOTE: Update String matches as needed.
        */
+      foreach (var pg in Patches)
       {
-        var filter = new List<PatchGroup>();
-        
-        foreach (var pg in Patches)
+        if (LAA && pg.Executable == "haloce.exe" && pg.Name.Contains("large address aware"))
         {
-          if (LAA               && pg.Executable == "haloce.exe" && pg.Name.Contains("large address aware"))
-          {
-            pg.Toggle = true;
-            filter.Add(pg);
-            continue;
-          }
-          if (DRM               && pg.Executable == "haloce.exe" && pg.Name.Contains("DRM"))
-          {
-            pg.Toggle = true;
-            filter.Add(pg);
-            continue;
-          }
-          if (FixLAN            && pg.Executable == "haloce.exe" && pg.Name.Contains("Bind server to 0.0.0.0"))
-          {
-            pg.Toggle = true;
-            filter.Add(pg);
-            continue;
-          }
-          if (NoSafe            && pg.Executable == "haloce.exe" && pg.Name.Contains("safe mode prompt"))
-          {
-            pg.Toggle = true;
-            filter.Add(pg);
-            continue;
-          }
-          if (NoGamma           && pg.Executable == "haloce.exe" && pg.Name.Contains("gamma"))
-          {
-            pg.Toggle = true;
-            filter.Add(pg);
-            continue;
-          }
-          if (Fix32Tex          && pg.Executable == "haloce.exe" && pg.Name.Contains("32-bit textures"))
-          {
-            pg.Toggle = true;
-            filter.Add(pg);
-            continue;
-          }
-          if (NoEULA            && pg.Executable == "haloce.exe" && pg.Name.Contains("EULA"))
-          {
-            pg.Toggle = true;
-            filter.Add(pg);
-            continue;
-          }
-          if (NoRegistryExit    && pg.Executable == "haloce.exe" && pg.Name.Contains("exit status"))
-          {
-            pg.Toggle = true;
-            filter.Add(pg);
-            continue;
-          }
-          if (NoAutoCenter      && pg.Executable == "haloce.exe" && pg.Name.Contains("auto-centering"))
-          {
-            pg.Toggle = true;
-            filter.Add(pg);
-            continue;
-          }
-          if (NoMouseAccel      && pg.Executable == "haloce.exe" && pg.Name.Contains("mouse acceleration"))
-          {
-            pg.Toggle = true;
-            filter.Add(pg);
-            continue;
-          }
-          if (BlockUpdates      && pg.Executable == "haloce.exe" && pg.Name.Contains("update checks"))
-          {
-            pg.Toggle = true;
-            filter.Add(pg);
-            continue;
-          }
-          if (BlockCamShake     && pg.Executable == "haloce.exe" && pg.Name.Contains("camera shaking"))
-          {
-            pg.Toggle = true;
-            filter.Add(pg);
-            continue;
-          }
-          if (BlockDescopeOnDMG && pg.Executable == "haloce.exe" && pg.Name.Contains("Prevent descoping when taking damage"))
-          {
-            pg.Toggle = true;
-            filter.Add(pg);
-            continue;
-          }
+          pg.Toggle = true;
+          FilteredPatches.Add(pg);
+          continue;
         }
-
-        FilteredPatches = filter;
+        if (DRM && pg.Executable == "haloce.exe" && pg.Name.Contains("DRM"))
+        {
+          pg.Toggle = true;
+          FilteredPatches.Add(pg);
+          continue;
+        }
+        if (FixLAN && pg.Executable == "haloce.exe" && pg.Name.Contains("Bind server to 0.0.0.0"))
+        {
+          pg.Toggle = true;
+          FilteredPatches.Add(pg);
+          continue;
+        }
+        if (NoSafe && pg.Executable == "haloce.exe" && pg.Name.Contains("safe mode prompt"))
+        {
+          pg.Toggle = true;
+          FilteredPatches.Add(pg);
+          continue;
+        }
+        if (NoGamma && pg.Executable == "haloce.exe" && pg.Name.Contains("gamma"))
+        {
+          pg.Toggle = true;
+          FilteredPatches.Add(pg);
+          continue;
+        }
+        if (Fix32Tex && pg.Executable == "haloce.exe" && pg.Name.Contains("32-bit textures"))
+        {
+          pg.Toggle = true;
+          FilteredPatches.Add(pg);
+          continue;
+        }
+        if (NoEULA && pg.Executable == "haloce.exe" && pg.Name.Contains("EULA"))
+        {
+          pg.Toggle = true;
+          FilteredPatches.Add(pg);
+          continue;
+        }
+        if (NoRegistryExit && pg.Executable == "haloce.exe" && pg.Name.Contains("exit status"))
+        {
+          pg.Toggle = true;
+          FilteredPatches.Add(pg);
+          continue;
+        }
+        if (NoAutoCenter && pg.Executable == "haloce.exe" && pg.Name.Contains("auto-centering"))
+        {
+          pg.Toggle = true;
+          FilteredPatches.Add(pg);
+          continue;
+        }
+        if (NoMouseAccel && pg.Executable == "haloce.exe" && pg.Name.Contains("mouse acceleration"))
+        {
+          pg.Toggle = true;
+          FilteredPatches.Add(pg);
+          continue;
+        }
+        if (BlockUpdates && pg.Executable == "haloce.exe" && pg.Name.Contains("update checks"))
+        {
+          pg.Toggle = true;
+          FilteredPatches.Add(pg);
+          continue;
+        }
+        if (BlockCamShake && pg.Executable == "haloce.exe" && pg.Name.Contains("camera shaking"))
+        {
+          pg.Toggle = true;
+          FilteredPatches.Add(pg);
+          continue;
+        }
+        if (BlockDescopeOnDMG && pg.Executable == "haloce.exe" && pg.Name.Contains("Prevent descoping when taking damage"))
+        {
+          pg.Toggle = true;
+          FilteredPatches.Add(pg);
+          continue;
+        }
       }
 
       /** Flexible patcher */
-      using (var fs = new FileStream(exePath, FileMode.Open, FileAccess.ReadWrite))
-      using (var ms = new MemoryStream(0x24B000))
-      using (var bw = new BinaryWriter(ms))
-      using (var br = new BinaryReader(ms))
+      try
       {
+        using (var fs = new FileStream(exePath, FileMode.Open, FileAccess.ReadWrite))
+        using (var ms = new MemoryStream(0x24B000))
+        using (var bw = new BinaryWriter(ms))
+        using (var br = new BinaryReader(ms))
         foreach (var PatchGroup in FilteredPatches)
-        {
-
-          foreach (var DataSet in PatchGroup.DataSets) // I hate this
           {
-            byte value  = PatchGroup.Toggle ? DataSet.Patch : DataSet.Original;
-            long offset = DataSet.Offset;
-            ms.Position = 0;
-            fs.Position = 0;
-            fs.CopyTo(ms);
-
-            ms.Position = offset;
-
-            if (br.ReadByte() != value)
+            foreach (var DataSet in PatchGroup.DataSets)
             {
-              ms.Position -= 1; /** restore position */
-              bw.Write(value);  /** write value      */
-
-              fs.Position = 0;
+              byte value  = PatchGroup.Toggle ? DataSet.Patch : DataSet.Original;
+              long offset = DataSet.Offset;
               ms.Position = 0;
-              ms.CopyTo(fs);
+              fs.Position = 0;
+              fs.CopyTo(ms);
 
-              Info($"Applied \"{PatchGroup.Name}\" patch to the HCE executable");
-            }
-            else
-            {
-              Info($"HCE executable already patched with \"{PatchGroup.Name}\"");
+              ms.Position = offset;
+
+              if (br.ReadByte() != value)
+              {
+                if (PatchGroup.Name.Contains("DRM") && PatchGroup.Toggle == false)
+                  return;
+
+                ms.Position -= 1; /** restore position */
+                bw.Write(value);  /** write value      */
+
+                fs.Position = 0;
+                ms.Position = 0;
+                ms.CopyTo(fs);
+
+                Info($"Applied \"{PatchGroup.Name}\" patch to the HCE executable");
+              }
+              else
+                Info($"HCE executable already patched with \"{PatchGroup.Name}\"");
             }
           }
-        }
       }
+      catch (Exception)
+      {
+        // We need to catch exceptions thrown by the using() statements.
+        throw;
+      }    
     }
 
     /// <summary>

--- a/spv3/loader/src/AmaiSosu.cs
+++ b/spv3/loader/src/AmaiSosu.cs
@@ -47,7 +47,7 @@ namespace SPV3
 
     public void Execute()
     {
-      Process.Start(Exists() ? Path : Address);
+      Process.Start(Exists() ? Path : Address).WaitForExit();
     }
 
     /// <summary>

--- a/spv3/loader/src/Install.cs
+++ b/spv3/loader/src/Install.cs
@@ -283,13 +283,13 @@ namespace SPV3
           "Installation has been successful! " +
           "Please install OpenSauce to the SPV3 folder OR Halo CE folder using AmaiSosu. Click OK to continue ...");
 
-        while(!Exists(Path.Combine(GetFolderPath(CommonApplicationData), "Kornner Studios", "Halo CE", "OpenSauceUI.pak")) ||
-              !Exists(Path.Combine(GetFolderPath(CommonApplicationData), "Kornner Studios", "Halo CE", "shaders", "gbuffer_shaders.shd")) ||
-              !Exists(Path.Combine(GetFolderPath(CommonApplicationData), "Kornner Studios", "Halo CE", "shaders", "pp_shaders.shd")))
-          new AmaiSosu { Path = Path.Combine(Target, Paths.AmaiSosu) }.Execute();
+
         try
         {
-          new AmaiSosu {Path = Path.Combine(Target, Paths.AmaiSosu)}.Execute();
+          while (!Exists(Path.Combine(GetFolderPath(CommonApplicationData), "Kornner Studios", "Halo CE", "OpenSauceUI.pak")) ||
+                !Exists(Path.Combine(GetFolderPath(CommonApplicationData), "Kornner Studios", "Halo CE", "shaders", "gbuffer_shaders.shd")) ||
+                !Exists(Path.Combine(GetFolderPath(CommonApplicationData), "Kornner Studios", "Halo CE", "shaders", "pp_shaders.shd")))
+            new AmaiSosu { Path = Path.Combine(Target, Paths.AmaiSosu) }.Execute();
         }
         catch (Exception e)
         {

--- a/spv3/loader/src/Install.cs
+++ b/spv3/loader/src/Install.cs
@@ -44,6 +44,7 @@ namespace SPV3
 {
   public class Install : INotifyPropertyChanged
   {
+    private const    string     _ssdRec   = "SPV3 must be installed to an SSD. Otherwise, you will experience loading hitches.";
     private readonly string     _source   = Path.Combine(CurrentDirectory, "data");
     private          bool       _canInstall;
     private          bool       _compress = false;
@@ -51,7 +52,7 @@ namespace SPV3
     private          Visibility _activation = Collapsed;
     private          Visibility _load     = Collapsed;
     private          Visibility _main     = Visible;
-    private          string     _status   = "Awaiting user input...";
+    private          string     _status   = _ssdRec;
     private          string     _target   = Path.Combine(GetFolderPath(Personal), "My Games", "Halo SPV3");
     private          string     _steamExe = Path.Combine(Steam, SteamExe);
     private          string     _steamStatus = "Find Steam.exe or its shortcut and we'll do the rest!";
@@ -167,23 +168,20 @@ namespace SPV3
 
       ValidateTarget(Target);
 
-      /**
-       * Activate SPV3 if Retail is installed
-       */
+      /** Activate SPV3 if Retail is installed */
       if (Registry.GameActivated("Retail")
         && (Kernel.hxe.Tweaks.Patches & Patcher.EXEP.DISABLE_DRM_AND_KEY_CHECKS) != 1)
       {
         Kernel.hxe.Tweaks.Patches |= Patcher.EXEP.DISABLE_DRM_AND_KEY_CHECKS;
       }
 
-      /**
-       * Determine if the current environment fulfills the installation requirements.
-       */
+      /** Determine if the current environment 
+       *  fulfills the installation requirements. */
       if (Registry.GameActivated("Custom")
           || Registry.GameActivated("Retail")
           || (Kernel.hxe.Tweaks.Patches & Patcher.EXEP.DISABLE_DRM_AND_KEY_CHECKS) == 1)
         return;
-      // else, prompt for activation
+      /** else, prompt for activation */
 
       Status     = "Please install a legal copy of Halo 1 before installing SPV3.";
       CanInstall = false;
@@ -223,7 +221,7 @@ namespace SPV3
             throw;
         }
 
-        /* MCC DRM Patch */
+        /** MCC DRM Patch */
 
         try
         {
@@ -236,7 +234,7 @@ namespace SPV3
             throw;
         }
 
-        /* shortcuts */
+        /** shortcuts */
         {
           void Shortcut(string shortcutPath)
           {
@@ -283,9 +281,7 @@ namespace SPV3
           "Installation has been successful! " +
           "Please install OpenSauce to the SPV3 folder OR Halo CE folder using AmaiSosu. Click OK to continue ...");
 
-        /** Install OpenSauce via AmaiSosu 
-         * 
-         */
+        /** Install OpenSauce via AmaiSosu */
         try
         {
           var amaiSosu = new AmaiSosu { Path = Path.Combine(Target, Paths.AmaiSosu) };
@@ -380,7 +376,7 @@ namespace SPV3
         {
           Kernel.hxe.Tweaks.Patches |= Patcher.EXEP.DISABLE_DRM_AND_KEY_CHECKS;
           Status = "Halo CEA Located via Steam." + NewLine
-                 + "Waiting for user to install SPV3." + NewLine;
+                 + _ssdRec + NewLine;
           CanInstall = true;
           Main       = Visible;
           Activation = Collapsed;
@@ -431,7 +427,7 @@ namespace SPV3
         WriteAllBytes(test, new byte[8]);
         Delete(test);
 
-        Status = "Waiting for user to install SPV3.";
+        Status = _ssdRec;
         CanInstall = true;
       }
       catch (Exception e)
@@ -586,7 +582,7 @@ namespace SPV3
           Main       = Visible;
           Activation = Collapsed;
           Status     = "Process Detection: Halo PC Found" + NewLine
-                     + "Waiting for user to install SPV3.";
+                     + _ssdRec;
           return;
         }
         else if (mcc)
@@ -596,7 +592,7 @@ namespace SPV3
           Main       = Visible;
           Activation = Collapsed;
           Status     = "Process Detection: MCC CEA Found" + NewLine
-                     + "Waiting for user to install SPV3.";
+                     + _ssdRec;
           return;
         }
         else Status = "Process Detection: MCC Found, but CEA not present";

--- a/spv3/loader/src/Install.cs
+++ b/spv3/loader/src/Install.cs
@@ -263,6 +263,10 @@ namespace SPV3
           "Installation has been successful! " +
           "Please install OpenSauce to the SPV3 folder OR Halo CE folder using AmaiSosu. Click OK to continue ...");
 
+        while(!Exists(Path.Combine(GetFolderPath(CommonApplicationData), "Kornner Studios", "Halo CE", "OpenSauceUI.pak")) ||
+              !Exists(Path.Combine(GetFolderPath(CommonApplicationData), "Kornner Studios", "Halo CE", "shaders", "gbuffer_shaders.shd")) ||
+              !Exists(Path.Combine(GetFolderPath(CommonApplicationData), "Kornner Studios", "Halo CE", "shaders", "pp_shaders.shd")))
+          new AmaiSosu { Path = Path.Combine(Target, Paths.AmaiSosu) }.Execute();
         try
         {
           new AmaiSosu {Path = Path.Combine(Target, Paths.AmaiSosu)}.Execute();

--- a/spv3/loader/src/Install.cs
+++ b/spv3/loader/src/Install.cs
@@ -206,16 +206,35 @@ namespace SPV3
           (o, s) => Status =
             "Installing SPV3. Please wait until this is finished!";
 
-        await Task.Run(() => { SFX.Extract(new SFX.Configuration
+        try
         {
-          Target     = new DirectoryInfo(Target),
-          Executable = new FileInfo(GetExecutingAssembly().Location)
-        }); });
+          await Task.Run(() =>
+          {
+            SFX.Extract(new SFX.Configuration
+            {
+              Target = new DirectoryInfo(Target),
+              Executable = new FileInfo(GetExecutingAssembly().Location)
+            });
+          });
+        }
+        catch(InvalidOperationException)
+        {
+          if (!Debug.IsDebug)
+            throw;
+        }
 
         /* MCC DRM Patch */
-        if ((Kernel.hxe.Tweaks.Patches & Patcher.EXEP.DISABLE_DRM_AND_KEY_CHECKS) != 0)
-          new Patcher().Write(Kernel.hxe.Tweaks.Patches, Path.Combine(Target, HXE.Paths.HCE.Executable));
 
+        try
+        {
+          if ((Kernel.hxe.Tweaks.Patches & Patcher.EXEP.DISABLE_DRM_AND_KEY_CHECKS) != 0)
+            new Patcher().Write(Kernel.hxe.Tweaks.Patches, Path.Combine(Target, HXE.Paths.HCE.Executable));
+        }
+        catch (Exception)
+        {
+          if (!Debug.IsDebug)
+            throw;
+        }
         /* shortcuts */
         {
           void Shortcut(string shortcutPath)

--- a/spv3/loader/src/Install.cs
+++ b/spv3/loader/src/Install.cs
@@ -345,25 +345,13 @@ namespace SPV3
 
     public void ValidateTarget(string path)
     {
-      /**
-       * Check validity of the specified target value.
+      /** Check validity of the specified target value.
+       * 
        */
       if (string.IsNullOrEmpty(path) 
         || !Directory.Exists(Path.GetPathRoot(path)))
       {
         Status = "Enter a valid path.";
-        CanInstall = false;
-        return;
-      }
-
-      /** 
-       * Check if path contains Program Files or Program Files (x86)
-       */
-      if (path.Contains(GetFolderPath(ProgramFiles))
-      || !string.IsNullOrEmpty(GetFolderPath(ProgramFilesX86)) 
-      && path.Contains(GetFolderPath(ProgramFilesX86)))
-      {
-        Status = "The game does not function correctly when install to Program Files. Please choose a difference location.";
         CanInstall = false;
         return;
       }
@@ -407,8 +395,31 @@ namespace SPV3
         return;
       }
 
-      /**
-       * Check available disk space. This will NOT work on UNC paths!
+      /** Check if the target is in Program Files or Program Files (x86)
+       * 
+       */
+      if (path.Contains(GetFolderPath(ProgramFiles))
+      || !string.IsNullOrEmpty(GetFolderPath(ProgramFilesX86)) 
+      && path.Contains(GetFolderPath(ProgramFilesX86)))
+      {
+        Status = "The game does not function correctly when install to Program Files. Please choose a difference location.";
+        CanInstall = false;
+        return;
+      }
+
+      /** Prohibit installing to MCC's folder
+       * 
+       */
+      if (path.Contains("Halo The Master Chief Collection"))
+      {
+        Status = "SPV3 does not run on MCC and it does not alter any game files within MCC." + NewLine 
+               + "It is a stand alone program built on top of Halo Custom Edition.";
+        CanInstall = false;
+        return;
+      }
+
+      /** Check available disk space. This will NOT work on UNC paths!
+       * 
        */
       try
       {

--- a/spv3/loader/src/Install.cs
+++ b/spv3/loader/src/Install.cs
@@ -283,13 +283,29 @@ namespace SPV3
           "Installation has been successful! " +
           "Please install OpenSauce to the SPV3 folder OR Halo CE folder using AmaiSosu. Click OK to continue ...");
 
-
+        /** Install OpenSauce via AmaiSosu 
+         * 
+         */
         try
         {
-          while (!Exists(Path.Combine(GetFolderPath(CommonApplicationData), "Kornner Studios", "Halo CE", "OpenSauceUI.pak")) ||
-                !Exists(Path.Combine(GetFolderPath(CommonApplicationData), "Kornner Studios", "Halo CE", "shaders", "gbuffer_shaders.shd")) ||
-                !Exists(Path.Combine(GetFolderPath(CommonApplicationData), "Kornner Studios", "Halo CE", "shaders", "pp_shaders.shd")))
-            new AmaiSosu { Path = Path.Combine(Target, Paths.AmaiSosu) }.Execute();
+          var amaiSosu = new AmaiSosu { Path = Path.Combine(Target, Paths.AmaiSosu) };
+          while (!Exists(Path.Combine(GetFolderPath(CommonApplicationData), "Kornner Studios", "Halo CE", "OpenSauceUI.pak"))
+              && !Exists(Path.Combine(GetFolderPath(CommonApplicationData), "Kornner Studios", "Halo CE", "shaders", "gbuffer_shaders.shd"))
+              && !Exists(Path.Combine(GetFolderPath(CommonApplicationData), "Kornner Studios", "Halo CE", "shaders", "pp_shaders.shd")))
+          {
+            try
+            {
+              amaiSosu.Execute();
+              if (!amaiSosu.Exists())
+                MessageBox.Show("Click OK after AmaiSosu is installed.");
+            }
+            catch(Exception e)
+            {
+              if (e.Message == "The operation was canceled by the user") // RunAs elevation not granted
+                continue;
+              else throw;
+            }
+          }
         }
         catch (Exception e)
         {

--- a/spv3/loader/src/Install.cs
+++ b/spv3/loader/src/Install.cs
@@ -230,11 +230,12 @@ namespace SPV3
           if ((Kernel.hxe.Tweaks.Patches & Patcher.EXEP.DISABLE_DRM_AND_KEY_CHECKS) != 0)
             new Patcher().Write(Kernel.hxe.Tweaks.Patches, Path.Combine(Target, HXE.Paths.HCE.Executable));
         }
-        catch (Exception)
+        catch (FileNotFoundException)
         {
           if (!Debug.IsDebug)
             throw;
         }
+
         /* shortcuts */
         {
           void Shortcut(string shortcutPath)

--- a/spv3/loader/src/Install.cs
+++ b/spv3/loader/src/Install.cs
@@ -168,11 +168,20 @@ namespace SPV3
       ValidateTarget(Target);
 
       /**
+       * Activate SPV3 if Retail is installed
+       */
+      if (Registry.GameActivated("Retail")
+        && (Kernel.hxe.Tweaks.Patches & Patcher.EXEP.DISABLE_DRM_AND_KEY_CHECKS) != 1)
+      {
+        Kernel.hxe.Tweaks.Patches |= Patcher.EXEP.DISABLE_DRM_AND_KEY_CHECKS;
+      }
+
+      /**
        * Determine if the current environment fulfills the installation requirements.
        */
-      if (Registry.GameExists("Custom")
-       || Registry.GameExists("Retail")
-       || ( Kernel.hxe.Tweaks.Patches & Patcher.EXEP.DISABLE_DRM_AND_KEY_CHECKS) == 1)
+      if (Registry.GameActivated("Custom")
+          || Registry.GameActivated("Retail")
+          || (Kernel.hxe.Tweaks.Patches & Patcher.EXEP.DISABLE_DRM_AND_KEY_CHECKS) == 1)
         return;
       // else, prompt for activation
 

--- a/spv3/loader/src/SPV3.csproj
+++ b/spv3/loader/src/SPV3.csproj
@@ -283,4 +283,7 @@
     <PreBuildEvent>git rev-parse --short HEAD &gt; "$(ProjectDir)\hash"
 </PreBuildEvent>
   </PropertyGroup>
+  <PropertyGroup>
+    <PostBuildEvent>del "$(TargetDir)MahApps.Metro.xml"</PostBuildEvent>
+  </PropertyGroup>
 </Project>

--- a/spv3/loader/src/SPV3.sln
+++ b/spv3/loader/src/SPV3.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Blend for Visual Studio 15
-VisualStudioVersion = 15.0.28307.572
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.30907.101
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SPV3", "SPV3.csproj", "{C6922C15-C0C1-46D0-B2BC-2B0FF2BAD82B}"
 EndProject


### PR DESCRIPTION
Resolves #135
Resolves #187

* Prohibit installing to MCC's direcotry
* Activate SPV3 if Retail is installed and CE isn't;
* Allow SPV3.Install.Commit() to succeed if it hasn't been compiled to SFX, but only for Debug builds;
* Prevent the DRM patch from being unpatched;
* Try to catch exceptions thrown by the using() statements in Patcher.Write();
* Remove unnecessary "filter" variable;
* Retry installing AmaiSosu if the user declines RunAs elevation;
* Prompt for OK to detect if OpenSauce was installed via unmanaged AmaiSosu (downloaded separately);

