### PR TITLE
64 bit process error

### DIFF
--- a/spv3/loader/src/Install.cs
+++ b/spv3/loader/src/Install.cs
@@ -573,8 +573,6 @@ namespace SPV3
             Status                    =  $"Process Detection: MCC CEA Found{NewLine}{_ssdRec}";
             break;
         }
-
-        Status = "Process Detection: MCC Found, but CEA not present";
       }
       else
         Status = $"Process Detection: No Matching Processes{NewLine}No MCC (with CEA), HPC, or HCE processes found.";

--- a/spv3/loader/src/SPV3.csproj
+++ b/spv3/loader/src/SPV3.csproj
@@ -41,6 +41,7 @@
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>


### PR DESCRIPTION
- Changes 
Fix the problem with it perfering 32bit which cause an issue with halo cea winstore version of 64bit process, this cause the "32 bit process cannot handle modules of a 64 bit process" NEEDs to be complied on 64bit machine (AnyCPU). Clean up text status.
-Test
Works locally using WinStore Halo MCC CEA after changes. 
-Other possible fixes
Could create a small "console" program running 64bit version which checks the winstore version. Reason can run a 64bit version in a .net vm made for 32bit version. 

