### PR TITLE
Regenerate Bad Player Profiles

### DIFF
--- a/hxe/kernel/src/HCE/LastProfile.cs
+++ b/hxe/kernel/src/HCE/LastProfile.cs
@@ -64,7 +64,6 @@ namespace HXE.HCE
         {
           var pathParam = System.IO.Path.GetDirectoryName(Path);
           var firstProfile = (Profile) Custom.Profile(pathParam, "New001");
-          var savegamesExists = Directory.Exists(Custom.Profiles(pathParam));
 
           try
           {
@@ -76,12 +75,12 @@ namespace HXE.HCE
             }
             else
             {
-              NewProfile.Generate(pathParam, this, firstProfile, makeScaffold: !savegamesExists);
+              NewProfile.Generate(pathParam, this, firstProfile);
             }
           }
           catch (System.Exception)
           {
-            NewProfile.Generate(pathParam, this, firstProfile, makeScaffold: !savegamesExists);
+            NewProfile.Generate(pathParam, this, firstProfile);
           }
         }
       }

--- a/hxe/kernel/src/HCE/LastProfile.cs
+++ b/hxe/kernel/src/HCE/LastProfile.cs
@@ -76,12 +76,12 @@ namespace HXE.HCE
             }
             else
             {
-              NewProfile.Generate(pathParam, this, firstProfile, savegamesExists);
+              NewProfile.Generate(pathParam, this, firstProfile, makeScaffold: !savegamesExists);
             }
           }
           catch (System.Exception)
           {
-            NewProfile.Generate(pathParam, this, firstProfile, savegamesExists);
+            NewProfile.Generate(pathParam, this, firstProfile, makeScaffold: !savegamesExists);
           }
         }
       }

--- a/hxe/kernel/src/HCE/LastProfile.cs
+++ b/hxe/kernel/src/HCE/LastProfile.cs
@@ -1,15 +1,15 @@
 /**
  * Copyright (c) 2019 Emilian Roman
  * Copyright (c) 2020 Noah Sherwin
- * 
+ *
  * This software is provided 'as-is', without any express or implied
  * warranty. In no event will the authors be held liable for any damages
  * arising from the use of this software.
- * 
+ *
  * Permission is granted to anyone to use this software for any purpose,
  * including commercial applications, and to alter it and redistribute it
  * freely, subject to the following restrictions:
- * 
+ *
  * 1. The origin of this software must not be misrepresented; you must not
  *    claim that you wrote the original software. If you use this software
  *    in a product, an acknowledgment in the product documentation would be
@@ -21,7 +21,6 @@
 
 using System.Collections.Generic;
 using System.IO;
-using System.Linq;
 using System.Text;
 using static System.Environment;
 using static HXE.Console;
@@ -60,23 +59,32 @@ namespace HXE.HCE
         var log = (File) Exception;
         log.AppendAllText(msg);
         Error(e.Message + " -- LASTPROFILE.LOAD FAILED");
-        
+
         Core("Recreating LastProf.txt...");
         {
-          Profile firstProfile = new Profile();
-          string userPath = System.IO.Path.GetDirectoryName(Path);
+          var pathParam = System.IO.Path.GetDirectoryName(Path);
+          var firstProfile = (Profile) Custom.Profile(pathParam, "New001");
+          var savegamesExists = Directory.Exists(Custom.Profiles(pathParam));
+
           try
           {
-            firstProfile = HCE.Profile.List(Custom.Profiles(userPath)).First();
             // TODO : validate profile. Is it corrupted?
-            Name = firstProfile.Name;
+            if (HCE.Profile.List().Count != 0)
+            {
+              firstProfile = HCE.Profile.List(Custom.Profiles(pathParam))[0];
+              Name = firstProfile.Name;
+            }
+            else
+            {
+              NewProfile.Generate(pathParam, this, firstProfile, savegamesExists);
+            }
           }
           catch (System.Exception)
           {
-            NewProfile.Generate(userPath, this, firstProfile, Directory.Exists(Custom.Profiles(userPath)));
+            NewProfile.Generate(pathParam, this, firstProfile, savegamesExists);
           }
         }
-      } 
+      }
     }
 
     /// <summary>

--- a/hxe/kernel/src/HCE/NewProfile.cs
+++ b/hxe/kernel/src/HCE/NewProfile.cs
@@ -1,5 +1,4 @@
 ﻿using System.IO;
-using System.Linq;
 using HXE.HCE;
 using static System.Environment;
 using static HXE.Console;
@@ -48,7 +47,7 @@ namespace HXE
         if (lastUsedExists)
           profile = (Profile) Custom.Profile(pathParam, lastprof.Profile);
         else if (Profile.List().Count != 0)
-          profile = Profile.List(Custom.Profiles(pathParam)).First();
+          profile = Profile.List(Custom.Profiles(pathParam))[0];
         else
           profile = (Profile) Custom.Profile(pathParam, "New001");
       }

--- a/hxe/kernel/src/HCE/NewProfile.cs
+++ b/hxe/kernel/src/HCE/NewProfile.cs
@@ -37,12 +37,12 @@ namespace HXE
 
       if (profile is null)
         profile = System.IO.File.Exists(Custom.Profile(pathParam, lastprof.Profile)) ?
-          (Profile) Custom.Profile(pathParam, lastprof.Profile) :
+          (Profile) Custom.Profile(pathParam, lastprof.Profile):
           (Profile) Custom.Profile(pathParam, "New001");
 
       bool lastprofExists = lastprof.Exists();
       bool profileExists = profile.Exists();
-      bool savegameExists = System.IO.File.Exists(Custom.Progress(pathParam, profile.Name));
+      bool savegameExists = System.IO.File.Exists(Custom.Progress(pathParam, profile.Details.Name));
 
       /** Double-check for existing files to determine if the saves scaffold
        * still needs to be created.

--- a/hxe/kernel/src/HCE/NewProfile.cs
+++ b/hxe/kernel/src/HCE/NewProfile.cs
@@ -7,7 +7,6 @@ using Directory = System.IO.Directory;
 
 namespace HXE
 {
-  /// <inheritdoc />
   /// <summary>
   ///   Object used for creating a new Player Profile.
   /// </summary>
@@ -16,317 +15,404 @@ namespace HXE
     /// <summary>
     ///   Generate a Player Profile and assign it as the LastProfile.
     /// </summary>
-    /// <param name="scaffold"    >Inherit and pass the bool indicating if the scaffold must be created.</param>
-    /// <param name="pathParam"   >Inherit and pass the -path parameter.</param>
-    /// <param name="lastprofile" >Inherit the LastProfile instance.</param>
-    /// <param name="profile"     >Inherit the Profile instance.</param>
-    public static void Generate(string pathParam, LastProfile lastprofile = null, Profile profile = null, bool scaffold = false)
+    /// <param name="pathParam" >Inherit and pass the -path parameter.</param>
+    /// <param name="lastprof"  >Inherit the LastProfile instance.</param>
+    /// <param name="profile"   >Inherit the Profile instance.</param>
+    /// <param name="scaffold"  >Inherit and pass the bool indicating if the scaffold must be created.</param>
+    public static void Generate(string pathParam,
+                                LastProfile lastprof = null,
+                                Profile profile = null,
+                                bool scaffold = false)
     {
-      /* handle defaulted parameters */
-      if (profile == null)
-        profile = new Profile();
-      if (lastprofile == null)
-        lastprofile = (LastProfile) pathParam;
+      if (string.IsNullOrWhiteSpace(pathParam))
+      {
+        throw new System.ArgumentException($"'{nameof(pathParam)}' cannot be null or whitespace.", nameof(pathParam));
+      }
 
       Core("Beginning to generate a new Player Profile");
-      /// todo:
-      ///   populate with default settings
-      ///     blam.sav has some defaults listed. What needs to be set manually?
-      profile.Path = Custom.Profile(pathParam, profile.Details.Name);
-      lastprofile.Profile = profile.Details.Name;
+
+      /** Handle Defaulted Parameters and set Exists booleans. */
+      if (lastprof is null)
+        lastprof = (LastProfile) Custom.LastProfile(pathParam);
+
+      if (profile is null)
+        profile = System.IO.File.Exists(Custom.Profile(pathParam, lastprof.Profile)) ?
+          (Profile) Custom.Profile(pathParam, lastprof.Profile) :
+          (Profile) Custom.Profile(pathParam, "New001");
+
+      bool lastprofExists = lastprof.Exists();
+      bool profileExists = profile.Exists();
+      bool savegameExists = System.IO.File.Exists(Custom.Progress(pathParam, profile.Name));
+
+      /** Double-check for existing files to determine if the saves scaffold
+       * still needs to be created.
+       * We only do this when scaffold is false in case the scaffold structure exists and
+       * needs to be recreated.*/
+      if (!scaffold)
+        scaffold = lastprofExists
+          && profileExists
+          && savegameExists;
+
+      /** Load settings from existing profile */
+      if (profileExists)
+        profile.Load();
+
+      lastprof.Profile = profile.Details.Name;
 
       if (!scaffold)
-        Scaffold(pathParam, lastprofile, profile);
+        Scaffold(pathParam, lastprof, profile);
       else
       {
         profile.Save();
-        lastprofile.Save();
+        lastprof.Save();
       }
     }
 
     /// <summary>
-    ///   Output the File.Path variable's current value. Verify its full path exists in the file system.
+    ///   Create file and folder structure for Profile.Generate().
     /// </summary>
-    public static void VerifyPath(string path)
+    /// <param name="pathParam"> -path parameter to pass to Halo and write to profiles.</param>
+    /// <param name="lastprof" > Object reperesentation of LastProf.txt.</param>
+    /// <param name="profile"  > Object representation of blam.sav.</param>
+    public static void Scaffold(string pathParam, LastProfile lastprof, Profile profile)
     {
-      bool isDir = System.IO.File.GetAttributes(path).HasFlag(FileAttributes.Directory);
+      if (string.IsNullOrWhiteSpace(pathParam))
+      {
+        throw new System.ArgumentException($"'{nameof(pathParam)}' cannot be null or empty.", nameof(pathParam));
+      }
 
-      Debug(NewLine
-        + NewLine + $"Path is currently \"{path}\""
-        + NewLine + $"The Full Path is \"{Path.GetFullPath(path)}\""
-        + NewLine + $"Path points to a folder? {isDir}"
-        + NewLine + $"\"{path}\" exists?" + (isDir? Directory.Exists(path) : System.IO.File.Exists(path))
-        );
-    }
+      if (lastprof is null)
+      {
+        throw new System.ArgumentNullException(nameof(lastprof));
+      }
 
-    /// <summary>
-    ///   Create file and folder structure for Profile.Generate() using variables from GenVars.
-    /// </summary>
-    /// <param name="path"    > -path parameter to pass to Halo and write to profiles.</param>
-    /// <param name="profile" > Object to represent as string.</param>
-    /// <param name="file"    > An instance of the File class</param>
-    public static void Scaffold(string path, LastProfile lastprofile, Profile profile)
-    {
+      if (profile is null)
+      {
+        throw new System.ArgumentNullException(nameof(profile));
+      }
+
       Core("Creating Scaffold...");
 
-      /** Scaffold Root
-       * Set Path to the -path parameter
-       * If it doesn't exist, create it.
-       * Print the full path to the console.
-       * e.g. ".\temp\"
-       */
-      var file = (File) path;
-      Directory.CreateDirectory(file.Path);
-      VerifyPath(file.Path);
+      /** Set Path to the -path executable parameter */
+      var file = (File) pathParam;
 
-      /** Savegames
-       * Set Path to the savegames directory
-       * If it doesn't exist, create it.
-       * e.g. ".\temp\savegames\
-       */
-      file.Path = Custom.Profiles(path);
-      Directory.CreateDirectory(file.Path);
-      VerifyPath(file.Path);
-
-      /** Profile's folder
-       * Set Path to the current Profile's directory, et cetera
-       * If it doesn't exist, create it.
-       */
-      file.Path = Custom.ProfileDirectory(path, profile.Details.Name);  /// e.g. ".\temp\savegames\New001\"
-      Directory.CreateDirectory(file.Path);
-      VerifyPath(file.Path);
-
-      /** Profile's Blam.sav
-       * Create blam.sav
-       * Write Input Blanks
-       *
-       * Produces a file identical to default_profile\00.sav
-       *
-       * <see cref="Profile.Offset"/>
-       */
-      using (var fs = new FileStream(Custom.Profile(path, profile.Details.Name), FileMode.OpenOrCreate)) /// e.g. ".\temp\savegames\New001\blam.sav"
-      using (var ms = new MemoryStream(8192))
-      using (var bw = new BinaryWriter(ms))
-      {
-        fs.Position = 0;
-        fs.CopyTo(ms);
-
-        /** Write Bindings filler (7fff) */
-        {
-          ms.Position = 0x13c;
-          while (ms.Position < 0x93a)
-          {
-            bw.Write((ushort) 0x7fff);
-          }
-        }
-
-        /** Write Gamepad Menu Bindings filler (ffff) */
-        {
-          ms.Position = 0x32A;
-          while (ms.Position != 0x33a)
-          {
-            bw.Write((ushort) 0xffff);
-          }
-        }
-
-
-        /** Unknown */
-
-        ms.Position = 0x0;
-        bw.Write((byte) 0x9);
-
-        ms.Position = 0x11a;
-        bw.Write((ushort) 0xffff);
-        bw.Write((ushort) 0x1);
-
-        ms.Position = 0x12E;
-        bw.Write((byte) 0x3);
-
-        ms.Position = 0x134;
-        bw.Write((ushort) 0x9);
-        bw.Write((ushort) 0xC);
-        bw.Write((ushort) 0x1B);
-        bw.Write((ushort) 0x1C);
-
-        ms.Position = 0x14E;
-        bw.Write((ushort) 0x12);
-
-        ms.Position = 0x170;
-        bw.Write((ushort) 0x3);
-        bw.Write((ushort) 0x5);
-        bw.Write((ushort) 0x13);
-        bw.Write((ushort) 0x2);
-        bw.Write((ushort) 0xD);
-        bw.Write((ushort) 0xF);
-        bw.Write((ushort) 0x10);
-
-        ms.Position = 0x18E;
-        bw.Write((ushort) 0x15);
-        bw.Write((ushort) 0x14);
-        bw.Write((ushort) 0x16);
-        bw.Write((ushort) 0x4);
-        bw.Write((ushort) 0x1);
-        bw.Write((ushort) 0x11);
-
-        ms.Position = 0x1A4;
-        bw.Write((ushort) 0x8);
-        ms.Position += 2;
-        bw.Write((ushort) 0xB);
-        bw.Write((ushort) 0xE);
-
-        ms.Position = 0x1BE;
-        bw.Write((ushort) 0xA);
-
-        ms.Position = 0x1C4;
-        bw.Write((ushort) 0x0);
-
-        ms.Position = 0x20E;
-        bw.Write((ushort) 0x7);
-        bw.Write((ushort) 0xB);
-        bw.Write((ushort) 0x6);
-
-        ms.Position = 0x21E;
-        bw.Write((ushort) 0x1A);
-        bw.Write((ushort) 0x19);
-        bw.Write((ushort) 0x17);
-        bw.Write((ushort) 0x18);
-
-        ms.Position = 0x93A;
-        bw.Write((ushort) 0x0000);
-        bw.Write((ushort) 0x0000);
-        bw.Write((byte) 0x80);
-        bw.Write((byte) 0x3F);
-        bw.Write((ushort) 0x0000);
-        bw.Write((byte) 0x80);
-        bw.Write((byte) 0x3F);
-        bw.Write((byte) 0xFC);
-        bw.Write((byte) 0x04);
-        bw.Write((byte) 0x41);
-        bw.Write((byte) 0x3E);
-        bw.Write((byte) 0xFC);
-        bw.Write((byte) 0x04);
-        bw.Write((byte) 0x41);
-        bw.Write((byte) 0x3E);
-        bw.Write((ushort) 0x0000);
-        bw.Write((byte) 0x00);
-        bw.Write((byte) 0x43);
-        bw.Write((ushort) 0x0000);
-        bw.Write((byte) 0x00);
-        bw.Write((byte) 0x43);
-        bw.Write((ushort) 0x0303);
-        bw.Write((ushort) 0x0303);
-        bw.Write((ushort) 0x0303);
-        bw.Write((ushort) 0x0303);
-        bw.Write((ushort) 0x0303);
-        bw.Write((ushort) 0x0000);
-        bw.Write((ushort) 0x0000);
-        bw.Write((byte) 0x40);
-        bw.Write((byte) 0x3f);
-        bw.Write((ushort) 0x0000);
-        bw.Write((byte) 0x40);
-        bw.Write((byte) 0x3f);
-
-        ms.Position = 0x962;
-        bw.Write((byte) 0x40);
-        bw.Write((byte) 0x3F);
-        bw.Write((byte) 0x0);
-        bw.Write((byte) 0x0);
-        bw.Write((byte) 0x40);
-        bw.Write((byte) 0x3F);
-
-        ms.Position = 0xA68;
-        bw.Write((byte) 0x20);
-        bw.Write((byte) 0x3);
-        bw.Write((byte) 0x58);
-        bw.Write((byte) 0x2);
-        bw.Write((byte) 0x3C);
-        bw.Write((byte) 0x0);
-        bw.Write((byte) 0x2);
-        bw.Write((byte) 0x2);
-        bw.Write((byte) 0x1);
-        bw.Write((byte) 0x1);
-        bw.Write((byte) 0x1);
-        bw.Write((byte) 0x2);
-        bw.Write((byte) 0x2);
-        bw.Write((byte) 0x2);
-        bw.Write((byte) 0x1);
-
-        ms.Position = 0xb78;
-        bw.Write((byte) 0xA);
-        bw.Write((byte) 0xA);
-        bw.Write((byte) 0x6);
-        bw.Write((byte) 0x0);
-        bw.Write((byte) 0x0);
-        bw.Write((byte) 0x1);
-        bw.Write((byte) 0x0);
-        bw.Write((byte) 0x2);
-
-        ms.Position = 0xC80;
-        bw.Write((byte) 0x3);
-        bw.Write((byte) 0x1);
-        bw.Write((byte) 0x1);
-        bw.Write((byte) 0x00);
-        bw.Write((ushort) 0x0000);
-        bw.Write((byte) 0x1);
-        bw.Write((byte) 0x1);
-
-        ms.Position = 0xD8C;
-        bw.Write(System.Text.Encoding.Unicode.GetBytes("Halo"));
-
-        ms.Position = 0xEBF;
-        bw.Write((byte) 0x3);
-
-        ms.Position = 0xFC0;
-        bw.Write((byte) 0x1);
-
-        ms.Position = 0x1002;
-        bw.Write( 0xFE);
-        ms.Position = 0x1003;
-        bw.Write(0x08);
-        ms.Position = 0x1004;
-        bw.Write(0xFF);
-        ms.Position = 0x1005;
-        bw.Write(0x08);
-
-        ms.Position = 0x1FFC;
-        bw.Write((byte) 0x50);
-        bw.Write((byte) 0x3B);
-        bw.Write((byte) 0xA1);
-        bw.Write((byte) 0x3C);
-
-        ms.Position = 0;
-        ms.CopyTo(fs);
-      }
-      profile.Save();
-      VerifyPath(Custom.Profile(path, profile.Details.Name));
-
-      /** Savegame.bin
-       * Create savegame.bin
-       * e.g. ".\temp\savegames\New001\savegame.bin"
-       */
-      file.Path = Custom.Progress(path, profile.Details.Name);
-      file.WriteAllBytes(new byte[0x480000]); /// 0x480000 == int 4718592
-      VerifyPath(file.Path);
-
-      /** Profile file (Waypoint)
-       * Create waypoint
-       * e.g. ".\temp\savegames\New001\New001"
-       */
-      file.Path = Custom.Waypoint(path, profile.Details.Name);
-      file.WriteAllText(Custom.Waypoint(path, profile.Details.Name));
-      VerifyPath(file.Path);
-
-      /** lastprof.txt
-       * Create or overwrite lastprof.txt
-       * e.g. ".\temp\lastprof.txt"
-       */
-      file.Path = Custom.LastProfile(path);
-      lastprofile.Path = file.Path;
-      lastprofile.Name = profile.Details.Name;
-      lastprofile.Save();
-      VerifyPath(file.Path);
+      RootDir();
+      SavegamesDir();
+      ProfileDir();
+      BlamSav();
+      SavegameBin();
+      ProfileWaypoint();
+      LastProfileTxt();
 
       Info("Scaffold Completed.");
+
+      /// <summary>
+      ///   Create the Scaffold root directory
+      /// </summary>
+      /// <example>
+      ///   ".\temp\"
+      /// </example>
+      void RootDir()
+      {
+        Directory.CreateDirectory(file.Path);
+        VerifyPath(file.Path);
+      }
+
+      /// <summary>
+      ///   Create the Savegames directory if it doesn't exist.
+      /// </summary>
+      /// <example>
+      ///   ".\temp\savegames\"
+      /// </example>
+      void SavegamesDir()
+      {
+        file.Path = Custom.Profiles(pathParam);
+        Directory.CreateDirectory(file.Path);
+        VerifyPath(file.Path);
+      }
+
+      /// <summary>
+      ///  Create Profile's folder.
+      /// </summary>
+      void ProfileDir()
+      {
+        file.Path = Custom.ProfileDirectory(pathParam, profile.Details.Name);  /// e.g. ".\temp\savegames\New001\"
+        Directory.CreateDirectory(file.Path);
+        VerifyPath(file.Path);
+      }
+
+      /// <summary>
+      ///   Create Profile's blam.sav
+      /// </summary>
+      /// <example>
+      ///   ".\temp\savegames\New001\blam.sav"
+      /// </example>
+      void BlamSav()
+      {
+        CreateBlam();
+        profile.Save();
+        VerifyPath(Custom.Profile(pathParam, profile.Details.Name));
+
+        /// <summary>
+        ///   Produces a file identical to default_profile\00.sav <br/>
+        ///   Write Input Blanks
+        /// </summary>
+        /// <see cref="Profile.Offset"/>
+        void CreateBlam()
+        {
+          using (var fs = new FileStream(Custom.Profile(pathParam, profile.Details.Name), FileMode.OpenOrCreate))
+          using (var ms = new MemoryStream(8192))
+          using (var bw = new BinaryWriter(ms))
+          {
+            fs.Position = 0;
+            fs.CopyTo(ms);
+
+            /** Write Bindings filler (7fff) */
+            ms.Position = 0x13c;
+            while (ms.Position < 0x93a)
+            {
+              bw.Write((ushort) 0x7fff);
+            }
+
+            /** Write Gamepad Menu Bindings filler (ffff) */
+            ms.Position = 0x32A;
+            while (ms.Position != 0x33a)
+            {
+              bw.Write((ushort) 0xffff);
+            }
+
+            /** Unknown */
+            {
+              ms.Position = 0x0;
+              bw.Write((byte) 0x9);
+
+              ms.Position = 0x11a;
+              bw.Write((ushort) 0xffff);
+              bw.Write((ushort) 0x1);
+
+              ms.Position = 0x12E;
+              bw.Write((byte) 0x3);
+
+              ms.Position = 0x134;
+              bw.Write((ushort) 0x9);
+              bw.Write((ushort) 0xC);
+              bw.Write((ushort) 0x1B);
+              bw.Write((ushort) 0x1C);
+
+              ms.Position = 0x14E;
+              bw.Write((ushort) 0x12);
+
+              ms.Position = 0x170;
+              bw.Write((ushort) 0x3);
+              bw.Write((ushort) 0x5);
+              bw.Write((ushort) 0x13);
+              bw.Write((ushort) 0x2);
+              bw.Write((ushort) 0xD);
+              bw.Write((ushort) 0xF);
+              bw.Write((ushort) 0x10);
+
+              ms.Position = 0x18E;
+              bw.Write((ushort) 0x15);
+              bw.Write((ushort) 0x14);
+              bw.Write((ushort) 0x16);
+              bw.Write((ushort) 0x4);
+              bw.Write((ushort) 0x1);
+              bw.Write((ushort) 0x11);
+
+              ms.Position = 0x1A4;
+              bw.Write((ushort) 0x8);
+              ms.Position += 2;
+              bw.Write((ushort) 0xB);
+              bw.Write((ushort) 0xE);
+
+              ms.Position = 0x1BE;
+              bw.Write((ushort) 0xA);
+
+              ms.Position = 0x1C4;
+              bw.Write((ushort) 0x0);
+
+              ms.Position = 0x20E;
+              bw.Write((ushort) 0x7);
+              bw.Write((ushort) 0xB);
+              bw.Write((ushort) 0x6);
+
+              ms.Position = 0x21E;
+              bw.Write((ushort) 0x1A);
+              bw.Write((ushort) 0x19);
+              bw.Write((ushort) 0x17);
+              bw.Write((ushort) 0x18);
+
+              ms.Position = 0x93A;
+              bw.Write((ushort) 0x0000);
+              bw.Write((ushort) 0x0000);
+              bw.Write((byte) 0x80);
+              bw.Write((byte) 0x3F);
+              bw.Write((ushort) 0x0000);
+              bw.Write((byte) 0x80);
+              bw.Write((byte) 0x3F);
+              bw.Write((byte) 0xFC);
+              bw.Write((byte) 0x04);
+              bw.Write((byte) 0x41);
+              bw.Write((byte) 0x3E);
+              bw.Write((byte) 0xFC);
+              bw.Write((byte) 0x04);
+              bw.Write((byte) 0x41);
+              bw.Write((byte) 0x3E);
+              bw.Write((ushort) 0x0000);
+              bw.Write((byte) 0x00);
+              bw.Write((byte) 0x43);
+              bw.Write((ushort) 0x0000);
+              bw.Write((byte) 0x00);
+              bw.Write((byte) 0x43);
+              bw.Write((ushort) 0x0303);
+              bw.Write((ushort) 0x0303);
+              bw.Write((ushort) 0x0303);
+              bw.Write((ushort) 0x0303);
+              bw.Write((ushort) 0x0303);
+              bw.Write((ushort) 0x0000);
+              bw.Write((ushort) 0x0000);
+              bw.Write((byte) 0x40);
+              bw.Write((byte) 0x3f);
+              bw.Write((ushort) 0x0000);
+              bw.Write((byte) 0x40);
+              bw.Write((byte) 0x3f);
+
+              ms.Position = 0x962;
+              bw.Write((byte) 0x40);
+              bw.Write((byte) 0x3F);
+              bw.Write((byte) 0x0);
+              bw.Write((byte) 0x0);
+              bw.Write((byte) 0x40);
+              bw.Write((byte) 0x3F);
+
+              ms.Position = 0xA68;
+              bw.Write((byte) 0x20);
+              bw.Write((byte) 0x3);
+              bw.Write((byte) 0x58);
+              bw.Write((byte) 0x2);
+              bw.Write((byte) 0x3C);
+              bw.Write((byte) 0x0);
+              bw.Write((byte) 0x2);
+              bw.Write((byte) 0x2);
+              bw.Write((byte) 0x1);
+              bw.Write((byte) 0x1);
+              bw.Write((byte) 0x1);
+              bw.Write((byte) 0x2);
+              bw.Write((byte) 0x2);
+              bw.Write((byte) 0x2);
+              bw.Write((byte) 0x1);
+
+              ms.Position = 0xb78;
+              bw.Write((byte) 0xA);
+              bw.Write((byte) 0xA);
+              bw.Write((byte) 0x6);
+              bw.Write((byte) 0x0);
+              bw.Write((byte) 0x0);
+              bw.Write((byte) 0x1);
+              bw.Write((byte) 0x0);
+              bw.Write((byte) 0x2);
+
+              ms.Position = 0xC80;
+              bw.Write((byte) 0x3);
+              bw.Write((byte) 0x1);
+              bw.Write((byte) 0x1);
+              bw.Write((byte) 0x00);
+              bw.Write((ushort) 0x0000);
+              bw.Write((byte) 0x1);
+              bw.Write((byte) 0x1);
+
+              ms.Position = 0xD8C;
+              bw.Write(System.Text.Encoding.Unicode.GetBytes("Halo"));
+
+              ms.Position = 0xEBF;
+              bw.Write((byte) 0x3);
+
+              ms.Position = 0xFC0;
+              bw.Write((byte) 0x1);
+
+              ms.Position = 0x1002;
+              bw.Write(0xFE);
+              ms.Position = 0x1003;
+              bw.Write(0x08);
+              ms.Position = 0x1004;
+              bw.Write(0xFF);
+              ms.Position = 0x1005;
+              bw.Write(0x08);
+
+              ms.Position = 0x1FFC;
+              bw.Write((byte) 0x50);
+              bw.Write((byte) 0x3B);
+              bw.Write((byte) 0xA1);
+              bw.Write((byte) 0x3C);
+            }
+
+            ms.Position = 0;
+            ms.CopyTo(fs);
+          }
+        }
+      }
+
+      /// <summary>
+      ///   Create Profile's savegame.bin.
+      /// </summary>
+      /// <example>
+      ///   ".\temp\savegames\New001\savegame.bin"
+      /// </example>
+      void SavegameBin()
+      {
+        file.Path = Custom.Progress(pathParam, profile.Details.Name);
+
+        /** Only create a new savegame.bin if one does not already exist. */
+        if(!file.Exists())
+        {
+          file.WriteAllBytes(new byte[0x480000]); /// 0x480000 == int 4718592
+        }
+
+        VerifyPath(file.Path);
+      }
+
+      /// <summary>
+      ///   Create Profile's Waypoint file.
+      /// </summary>
+      /// <example>
+      ///   ".\temp\savegames\New001\New001"
+      /// </example>
+      void ProfileWaypoint()
+      {
+        file.Path = Custom.Waypoint(pathParam, profile.Details.Name);
+        file.WriteAllText(Custom.Waypoint(pathParam, profile.Details.Name));
+        VerifyPath(file.Path);
+      }
+
+      /// <summary>
+      ///   Save Profile to lastprof.txt
+      /// </summary>
+      /// <example>
+      ///   ".\temp\lastprof.txt"
+      /// </example>
+      void LastProfileTxt()
+      {
+        file.Path = Custom.LastProfile(pathParam);
+        lastprof.Path = file.Path;
+        lastprof.Name = profile.Details.Name;
+        lastprof.Save();
+        VerifyPath(file.Path);
+      }
+
+      /// <summary>
+      ///   Output the File.Path variable's current value. Verify its full path exists in the file system.
+      /// </summary>
+      void VerifyPath(string path)
+      {
+        bool isDir = System.IO.File.GetAttributes(path).HasFlag(FileAttributes.Directory);
+
+        Debug(NewLine
+          + NewLine + $"Path is currently \"{path}\""
+          + NewLine + $"The Full Path is \"{Path.GetFullPath(path)}\""
+          + NewLine + $"Path points to a folder? {isDir}"
+          + NewLine + $"\"{path}\" exists?" + (isDir? Directory.Exists(path) : System.IO.File.Exists(path))
+          );
+      }
     }
   }
 }

--- a/hxe/kernel/src/HCE/NewProfile.cs
+++ b/hxe/kernel/src/HCE/NewProfile.cs
@@ -17,20 +17,26 @@ namespace HXE
     ///   Generate a Player Profile and assign it as the LastProfile.
     /// </summary>
     /// <param name="scaffold"    >Inherit and pass the bool indicating if the scaffold must be created.</param>
-    /// <param name="path"        >Inherit and pass the -path parameter.</param>
+    /// <param name="pathParam"   >Inherit and pass the -path parameter.</param>
     /// <param name="lastprofile" >Inherit the LastProfile instance.</param>
     /// <param name="profile"     >Inherit the Profile instance.</param>
-    public static void Generate(string path, LastProfile lastprofile, Profile profile, bool scaffold)
+    public static void Generate(string pathParam, LastProfile lastprofile = null, Profile profile = null, bool scaffold = false)
     {
+      /* handle defaulted parameters */
+      if (profile == null)
+        profile = new Profile();
+      if (lastprofile == null)
+        lastprofile = (LastProfile) pathParam;
+
       Core("Beginning to generate a new Player Profile");
       /// todo:
       ///   populate with default settings
       ///     blam.sav has some defaults listed. What needs to be set manually?
-      profile.Path = Custom.Profile(path, profile.Details.Name);
+      profile.Path = Custom.Profile(pathParam, profile.Details.Name);
       lastprofile.Profile = profile.Details.Name;
 
       if (!scaffold)
-        Scaffold(path, lastprofile, profile);
+        Scaffold(pathParam, lastprofile, profile);
       else
       {
         profile.Save();

--- a/hxe/kernel/src/HCE/Profile.cs
+++ b/hxe/kernel/src/HCE/Profile.cs
@@ -410,7 +410,7 @@ namespace HXE.HCE
     /// </summary>
     public void Load()
     {
-      using (var reader = new BinaryReader(System.IO.File.Open(Path, FileMode.Open)))
+      using (var reader = new BinaryReader(System.IO.File.Open(Path, FileMode.Open, FileAccess.Read, FileShare.Read)))
       {
         bool GetBoolean(Offset offset)
         {

--- a/hxe/kernel/src/Kernel.cs
+++ b/hxe/kernel/src/Kernel.cs
@@ -107,12 +107,50 @@ namespace HXE
           configuration.Mode = Configuration.ConfigurationMode.SPV33;
       }
 
+      CheckProfileIntegrity(); /* Profile Integrity Check */
       Init(); /* initc.txt declarations */
       Blam(); /* blam.sav enhancements  */
       Open(); /* opensauce declarations */
       Exec(); /* haloce.exe invocation  */
 
       Core("CORE.MAIN: Successfully updated the initiation, profile and OS files, and invoked the HCE executable.");
+
+      void CheckProfileIntegrity()
+      {
+        try
+        {
+          var pathParam = executable.Profile.Path;
+          var lastprof = (LastProfile) Custom.LastProfile(pathParam);
+
+          if (Exists(lastprof.Path))
+          {
+            lastprof.Load();
+            var profilePath = Custom.Profile(pathParam, lastprof.Profile);
+
+            using (FileStream fs = new FileStream(profilePath, FileMode.Open, FileAccess.Read))
+            using (MemoryStream ms = new MemoryStream((int) fs.Length))
+            using (BinaryReader br = new BinaryReader(ms))
+            {
+              fs.CopyTo(ms);
+              ms.Position = 0;
+
+              var firstByte = br.ReadInt16();
+              if (firstByte != 0x09)
+              {
+                NewProfile.Generate(pathParam, lastprof, new Profile(), false);
+              }
+            }
+          }
+          else
+          {
+            NewProfile.Generate(pathParam, lastprof, new Profile(), false);
+          }
+        }
+        catch (Exception)
+        {
+
+        }
+      }
 
       /**
        * We declare the contents of the initiation file in this method before dealing with the profile enhancements and

--- a/hxe/kernel/src/Kernel.cs
+++ b/hxe/kernel/src/Kernel.cs
@@ -137,18 +137,18 @@ namespace HXE
               var firstByte = br.ReadInt16();
               if (firstByte != 0x09)
               {
-                NewProfile.Generate(pathParam, lastprof, new Profile(), false);
+                NewProfile.Generate(pathParam, lastprof);
               }
             }
           }
           else
           {
-            NewProfile.Generate(pathParam, lastprof, new Profile(), false);
+            NewProfile.Generate(pathParam, lastprof);
           }
         }
         catch (Exception)
         {
-
+          Error("KERNEL.CheckProfileIntegrity() threw an unexpected exception and failed to complete.");
         }
       }
 
@@ -246,26 +246,21 @@ namespace HXE
                  */
                 if (profiles.Count != 0)
                 {
-                  foreach (Profile profile in profiles)
-                  {
-                    if (profile.Exists())
-                      validProfiles.Add(profile); // todo: implement better validation
-                  }
-                  lastprof.Profile = validProfiles[0].Details.Name;
+                  lastprof.Profile = profiles[0];
                   lastprof.Save();
                 }
                 else
                 {
                   Error("No profiles found in savegames folder.");
                   Core("Generating new profile");
-                  NewProfile.Generate(executable.Profile.Path, lastprof, new Profile(), false);
+                  NewProfile.Generate(executable.Profile.Path, lastprof);
                 }
               }
               else
               {
                 Error("Savegames folder does not exist.");
                 Core("Creating savegames folder and a new profile...");
-                NewProfile.Generate(executable.Profile.Path, lastprof, new Profile(), false);;
+                NewProfile.Generate(executable.Profile.Path, lastprof);
               }
               name = lastprof.Profile;
               save = (Progress) Custom.Progress(executable.Profile.Path, name);
@@ -402,10 +397,14 @@ namespace HXE
         catch (FileNotFoundException)
         {
           var lastprof = (LastProfile) Custom.LastProfile(executable.Profile.Path);
-          var scaffold = lastprof.Exists() && System.IO.File.Exists(Custom.Profile(executable.Profile.Path, lastprof.Profile));
+          var prof = (Profile) Custom.Profile(executable.Profile.Path, lastprof.Profile);
+          var scaffold = lastprof.Exists() && prof.Exists();
 
           if (!lastprof.Exists())
             Core("Lastprof.txt does not exist.");
+
+          if (!prof.Exists())
+            prof = (Profile) Custom.Profile(executable.Profile.Path, "New001");
 
           if (!scaffold)
             Debug("Savegames scaffold doesn't exist.");
@@ -413,7 +412,7 @@ namespace HXE
             Debug("Savegames scaffold detected.");
 
           Core("Calling LastProfile.Generate()...");
-          NewProfile.Generate(executable.Profile.Path, lastprof, blam = new Profile(), scaffold);
+          NewProfile.Generate(executable.Profile.Path, lastprof, blam = prof, scaffold);
         }
         catch (Exception e)
         {


### PR DESCRIPTION
- [x] Check if the last-used player profile was created by the first NewProfile Generator.
    There's a small chance this won't work if the first Short value happens to be the correct value e.g. keycode 0x0009 was written to that position.
- [x] If true, copy existing settings to a new blam.sav and overwrite the old one.
- [x] Do not delete anything else.